### PR TITLE
Skip large files

### DIFF
--- a/.github/workflows/ghbuild.yml
+++ b/.github/workflows/ghbuild.yml
@@ -104,6 +104,10 @@ jobs:
           name: qa-json-artifact
           path: ./output/qa.json  # Adjust the path based on where qa.json is located
 
+      - name: Remove files larger than 100MB from output
+        run: |
+          echo "Removing files > 100MB from ./output"
+          find ./output -type f -size +100M -print -delete
 
       - name: Get branch name
         run: echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV

--- a/.github/workflows/ghbuild.yml
+++ b/.github/workflows/ghbuild.yml
@@ -5,6 +5,7 @@
 # 2021-11-26: (JCT): Reusable workflow
 # 2022-01-28: (JCT): add auto-create gh-pages if it doesn't exist
 # 2023-01-22: (JCT): use checkout action v3, and JamesIves/github-pages-deploy-action@v4
+# 2025-04-24: (JCT): delete file larger than 100MB from GH pages
 
 
 # Make sure your repo has a branch called gh-pages


### PR DESCRIPTION
Fixes #21 by simply discarding the big files

This allows ANC to build again: https://github.com/WorldHealthOrganization/smart-anc/actions/runs/14640736655

for review before merging @litlfred @ritikarawlani 