### PR TITLE
Add script to strip binary ELM data from Library resources

### DIFF
--- a/.github/workflows/ghbuild.yml
+++ b/.github/workflows/ghbuild.yml
@@ -600,6 +600,30 @@ jobs:
       # Download-if-missing logic runs on the host (curl), which writes
       # into the volume-mounted workspace visible inside Docker.
 
+      - name: DAK Postprocessing - Strip binary data from Library resources
+        if: inputs.do_dak != 'false' && env.DAK_ENABLED == 'true'
+        run: |
+          echo "Stripping encoded binary data from Library resource files..."
+
+          # Check if the script exists locally, download if needed
+          if [ ! -f "input/scripts/strip_library_binaries.py" ]; then
+            echo "strip_library_binaries.py not found locally, downloading from smart-base repository..."
+            mkdir -p input/scripts
+            curl -L -f -o "input/scripts/strip_library_binaries.py" \
+              "${SCRIPTS_BASE_URL}/input/scripts/strip_library_binaries.py" \
+              2>/dev/null || echo "Failed to download strip_library_binaries.py"
+          else
+            echo "Using local strip_library_binaries.py"
+          fi
+
+          # Run inside the IG publisher container
+          if [ -f "input/scripts/strip_library_binaries.py" ]; then
+            docker exec -w /work ig-run python3 input/scripts/strip_library_binaries.py
+            echo "✅ Library binary data stripped"
+          else
+            echo "⚠️ strip_library_binaries.py not available, skipping"
+          fi
+
       - name: DAK Postprocessing - Generate JSON Schemas
         if: inputs.do_dak != 'false' && env.DAK_ENABLED == 'true'
         run: |

--- a/input/images/translations/images.pot
+++ b/input/images/translations/images.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,2384 +16,2384 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L94
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L94
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:94
 msgid "(Agile/Scrum) and tooling"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L288
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L288
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:288
 msgid "(Component 4)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L190
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L190
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:190
 msgid "(Component 5)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L197
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L197
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:197
 msgid "(Component 6)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L211
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L211
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:211
 msgid "(Component 8)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L408
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L408
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:408
 msgid "(country visits/interviews)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L726
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L726
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:726
 msgid "(governance)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L107
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L107
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:107
 msgid "(guidelines, registers, policies)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L617
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L617
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:617
 msgid "(qa.html)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L801
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L801
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:801
 msgid "(StructureMaps, CQL, Measures)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L967
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L967
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:967
 msgid "(vX.Y.Z)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L46
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L46
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:46
 msgid "1"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L59
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L59
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:59
 msgid "2"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L263
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L263
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:263
 msgid "2)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L72
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L72
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:72
 msgid "3"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L85
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L85
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:85
 msgid "4"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L98
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L98
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:98
 msgid "5"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L111
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L111
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:111
 msgid "6"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L124
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L124
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:124
 msgid "7"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L204
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L204
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:204
 msgid "7)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L137
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L137
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:137
 msgid "8"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L150
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L150
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:150
 msgid "9"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L143
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L143
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:143
 msgid "A non-exhaustive list of key functions and non-functional requirements for a digital tracking and decision support system"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L629
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L629
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:629
 msgid "All issues resolved?"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L839
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L839
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:839
 msgid "Approve IG for publication"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L145
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L145
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:145
 msgid "Assign work and begin sprint cycle"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L566
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L566
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:566
 msgid "Author ActorDefinitions (reuse"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L287
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L287
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:287
 msgid "Author BPMN business processes"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L514
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L514
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:514
 msgid "Author CodeSystems, ValueSets,"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L527
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L527
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:527
 msgid "Author CQL (decision logic,"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L489
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L489
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:489
 msgid "Author FHIR profiles"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L262
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L262
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:262
 msgid "Author generic personas (Component"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L476
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L476
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:476
 msgid "Author logical models from L2 data"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L579
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L579
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:579
 msgid "Author Measures, Requirements,"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L553
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L553
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:553
 msgid "Author PlanDefinitions (processes,"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L501
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L501
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:501
 msgid "Author questionnaires and structure"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L275
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L275
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:275
 msgid "Author user scenarios (Component 3)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L10
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L10
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:10
 msgid "BPMN"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L916
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L916
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:916
 msgid "branch"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L78
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L78
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:78
 msgid "Brief narrative description of how the targeted personas may engage with the digital system"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L20
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L20
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:20
 msgid "Business Analyst"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L88
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L88
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:88
 msgid "Business Processes & Workflows"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L440
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L440
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:440
 msgid "Clinical Review Complete"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L30
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L30
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:30
 msgid "Clinical SME"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L18
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L18
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:18
 msgid "cluster_Participant_BusinessAnalyst"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L28
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L28
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:28
 msgid "cluster_Participant_ClinicalSME"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L33
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L33
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:33
 msgid "cluster_Participant_FHIRModeller"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L13
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L13
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:13
 msgid "cluster_Participant_ProgrammeManager"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L48
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L48
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:48
 msgid "cluster_Participant_PublicationManager"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L43
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L43
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:43
 msgid "cluster_Participant_QCReviewer"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L38
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L38
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:38
 msgid "cluster_Participant_Terminologist"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L53
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L53
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:53
 msgid "cluster_Participant_Translator"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L23
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L23
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:23
 msgid "cluster_SubProcess_PerBP"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L541
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L541
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:541
 msgid "code systems"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L567
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L567
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:567
 msgid "Commons)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L872
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L872
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:872
 msgid "completeness"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L225
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L225
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L307
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L307
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:225
 #: input/images/SGAuthoring.DAKLifecycle.svg:307
 msgid "components"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L40
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L40
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:40
 msgid "Components of a L2 Digital Adaptation Kit (DAK)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L515
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L515
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:515
 msgid "ConceptMaps"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L378
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L378
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:378
 msgid "consistency"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L101
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L101
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:101
 msgid "Core Data Elements"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1043
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1043
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1043
 msgid "Create example resources per UN"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L966
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L966
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:966
 msgid "Create GitHub release and tag"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L941
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L941
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:941
 msgid "Create publication-request.json"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L171
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L171
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:171
 msgid "current sprint scope"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L395
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L395
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:395
 msgid "DAK Components Ready for Review"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L61
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L61
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:61
 msgid "DAK Development Initiated"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L104
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L104
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:104
 msgid "Data elements, used for clinical decision-making, indicators, and other data needs"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L114
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L114
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:114
 msgid "Decision Support Logic"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L117
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L117
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:117
 msgid "Decision tables representing counselling and treatment algorithms, scheduling logic"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L554
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L554
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:554
 msgid "decision tables)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L189
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L189
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:189
 msgid "Define core data elements"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L67
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L67
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:67
 msgid "Define DAK scope, purpose, and"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L217
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L217
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:217
 msgid "Define functional/non-functional"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L81
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L81
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:81
 msgid "define RASCI matrix"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L196
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L196
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:196
 msgid "Develop decision-support logic"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L203
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L203
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:203
 msgid "Develop scheduling logic (Component"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L477
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L477
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L701
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L701
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:477
 #: input/images/SGAuthoring.DAKLifecycle.svg:701
 msgid "dictionary"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L183
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L183
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:183
 msgid "Draft detailed workflow annotations"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L119
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L119
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:119
 msgid "Draft project roadmap, backlog, and"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L437
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L437
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:437
 msgid "End_ClinReview"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L362
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L362
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:362
 msgid "End_L2"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L660
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L660
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:660
 msgid "End_L3"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L155
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L155
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:155
 msgid "End_Planning"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1016
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1016
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1016
 msgid "End_Pub"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L856
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L856
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:856
 msgid "End_QC"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L736
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L736
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:736
 msgid "End_Term"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1072
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1072
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1072
 msgid "End_Trans"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L93
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L93
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:93
 msgid "Establish development process"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L35
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L35
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:35
 msgid "FHIR Modeller"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L351
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L351
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:351
 msgid "Finalize L2 DAK for L3 authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L604
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L604
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:604
 msgid "Fix QA issues from review"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L25
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L25
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:25
 msgid "For each business process"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L80
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L80
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:80
 msgid "Form DAK development team and"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L133
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L133
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:133
 msgid "format"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L140
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L140
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:140
 msgid "Functional & Non-functional Requirements"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L106
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L106
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:106
 msgid "Gather source documents"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L62
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L62
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:62
 msgid "Generic Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L91
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L91
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:91
 msgid "Generic workflows representing clinical and non-clinical processes"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L407
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L407
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:407
 msgid "Ground-truth with field practice"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L627
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L627
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:627
 msgid "GW_L3Done"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L653
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L653
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:653
 msgid "GW_L3Done->Task_CompleteL3"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L639
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L639
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:639
 msgid "GW_L3Done->Task_RunBuild"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L330
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L330
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:330
 msgid "GW_MoreSprints"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L355
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L355
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:355
 msgid "GW_MoreSprints->Task_FinalizeL2"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L342
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L342
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:342
 msgid "GW_MoreSprints->Task_IncorporateFeedback"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L811
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L811
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:811
 msgid "GW_QCPass"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L843
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L843
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:843
 msgid "GW_QCPass->Task_ApprovePublication"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L830
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L830
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:830
 msgid "GW_QCPass->Task_ReportIssues"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L49
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L49
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:49
 msgid "Health Interventions & Recommendations"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L421
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L421
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:421
 msgid "identify gaps"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L249
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L249
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:249
 msgid "Identify health interventions and"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L751
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L751
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:751
 msgid "IG Build Available"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L306
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L306
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:306
 msgid "Incorporate SME feedback into DAK"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L127
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L127
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:127
 msgid "Indicators & Monitoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L130
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L130
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:130
 msgid "Indicators for reporting & monitoring with numerator, denominator of data elements"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L452
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L452
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:452
 msgid "L2 DAK Available"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L365
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L365
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:365
 msgid "L2 DAK Complete"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L648
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L648
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:648
 msgid "L3 authoring complete - ready for"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L663
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L663
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:663
 msgid "L3 Complete"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1031
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1031
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1031
 msgid "L3 Content Ready"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1044
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1044
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1044
 msgid "language"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L210
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L210
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:210
 msgid "List indicators and metrics"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L700
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L700
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:700
 msgid "Map concepts to WHO Commons"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L713
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L713
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:713
 msgid "Map to ICD-11, SNOMED CT, LOINC"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L502
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L502
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:502
 msgid "maps"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L676
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L676
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:676
 msgid "metadata"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L332
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L332
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:332
 msgid "More sprints needed?"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L642
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L642
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:642
 msgid "No - fix and rebuild"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L833
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L833
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:833
 msgid "No - issues found"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L358
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L358
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:358
 msgid "No - L2 finalized"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L725
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L725
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:725
 msgid "Onboard new concepts to Commons"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L915
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L915
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:915
 msgid "Optionally create release-candidate"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L132
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L132
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:132
 msgid "Plan SME consultation schedule and"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L158
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L158
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:158
 msgid "Planning Complete"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L788
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L788
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:788
 msgid "profiles)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L15
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L15
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:15
 msgid "Programme Manager"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L420
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L420
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:420
 msgid "Provide clinical feedback and"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1019
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1019
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1019
 msgid "Publication Complete"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L50
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L50
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:50
 msgid "Publication Manager"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L813
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L813
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:813
 msgid "Publication ready?"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L903
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L903
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:903
 msgid "QC Approval Received"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L859
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L859
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:859
 msgid "QC Complete"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L45
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L45
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:45
 msgid "QC Reviewer"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L320
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L320
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:320
 msgid "recommendations"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L250
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L250
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:250
 msgid "recommendations (Component 1)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L52
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L52
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:52
 msgid "Relevant health interventions and recommendations from the WHO guideline and guidance"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L825
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L825
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:825
 msgid "Report issues to author for"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L992
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L992
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:992
 msgid "Request WHO team to update"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L218
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L218
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:218
 msgid "requirements (Component 9)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1005
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1005
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1005
 msgid "Reset main branch to draft, update"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L826
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L826
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:826
 msgid "resolution"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L649
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L649
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:649
 msgid "review"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L884
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L884
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:884
 msgid "Review changes and determine"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L616
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L616
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:616
 msgid "Review IG Publisher QA report"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L763
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L763
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:763
 msgid "Review L1 and L2 checklist items"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L170
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L170
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:170
 msgid "Review L1 source documents for"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L775
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L775
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:775
 msgid "Review L3 and L4 checklist items"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L540
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L540
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:540
 msgid "Review terminology bindings and"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L871
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L871
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:871
 msgid "Review translated content for"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L65
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L65
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:65
 msgid "Roles, responsibilities, and essential interventions performed by targeted personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L953
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L953
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:953
 msgid "Run final IG Publisher build and"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L592
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L592
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:592
 msgid "Run IG Publisher build"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L580
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L580
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:580
 msgid "Scenarios, Tests"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L528
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L528
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:528
 msgid "scheduling, indicators)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L464
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L464
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:464
 msgid "Set up IG repository from template"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L993
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L993
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:993
 msgid "smart.who.int"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L237
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L237
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:237
 msgid "Sprint Begins"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L120
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L120
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:120
 msgid "sprint cadence"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L393
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L393
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:393
 msgid "Start_ClinReview"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L399
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L399
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:399
 msgid "Start_ClinReview->Task_ValidateClinical"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L235
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L235
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:235
 msgid "Start_L2"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L241
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L241
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:241
 msgid "Start_L2->Task_ReviewL1"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L450
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L450
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:450
 msgid "Start_L3"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L456
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L456
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:456
 msgid "Start_L3->Task_VerifyL2Input"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L59
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L59
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:59
 msgid "Start_Planning"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L72
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L72
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:72
 msgid "Start_Planning->Task_Scoping"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L901
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L901
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:901
 msgid "Start_Pub"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L907
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L907
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:907
 msgid "Start_Pub->Task_PrepareRelease"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L749
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L749
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:749
 msgid "Start_QC"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L755
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L755
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:755
 msgid "Start_QC->Task_ReviewQA"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L686
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L686
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:686
 msgid "Start_Term"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L692
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L692
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:692
 msgid "Start_Term->Task_ReviewTermBindings"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1029
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1029
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1029
 msgid "Start_Trans"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1035
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1035
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1035
 msgid "Start_Trans->Task_TranslateContent"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L224
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L224
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:224
 msgid "Streamline and cross-check all DAK"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1056
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1056
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1056
 msgid "Submit translations for review"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L388
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L388
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:388
 msgid "SubProcess_PerBP"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L68
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L68
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:68
 msgid "target audience"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L837
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L837
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:837
 msgid "Task_ApprovePublication"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L889
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L889
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:889
 msgid "Task_ApprovePublication->Task_PrepareRelease"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L876
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L876
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:876
 msgid "Task_ApprovePublication->Task_ReviewTranslatedContent"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L143
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L143
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:143
 msgid "Task_AssignWork"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L162
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L162
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:162
 msgid "Task_AssignWork->End_Planning"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L175
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L175
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:175
 msgid "Task_AssignWork->Task_ReviewL1"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L564
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L564
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:564
 msgid "Task_AuthorActors"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L584
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L584
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:584
 msgid "Task_AuthorActors->Task_AuthorRemainingL3"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L285
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L285
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:285
 msgid "Task_AuthorBPMN"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L298
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L298
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:298
 msgid "Task_AuthorBPMN->Task_DetailWorkflow"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L525
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L525
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:525
 msgid "Task_AuthorCQL"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L558
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L558
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:558
 msgid "Task_AuthorCQL->Task_AuthorPlanDefs"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L474
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L474
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:474
 msgid "Task_AuthorLogicalModels"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L493
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L493
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:493
 msgid "Task_AuthorLogicalModels->Task_AuthorProfiles"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L260
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L260
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:260
 msgid "Task_AuthorPersonas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L279
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L279
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:279
 msgid "Task_AuthorPersonas->Task_AuthorScenarios"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L551
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L551
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:551
 msgid "Task_AuthorPlanDefs"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L571
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L571
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:571
 msgid "Task_AuthorPlanDefs->Task_AuthorActors"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L487
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L487
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:487
 msgid "Task_AuthorProfiles"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L506
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L506
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:506
 msgid "Task_AuthorProfiles->Task_AuthorQuestionnaires"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L499
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L499
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:499
 msgid "Task_AuthorQuestionnaires"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L519
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L519
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:519
 msgid "Task_AuthorQuestionnaires->Task_AuthorTerminology"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L577
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L577
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:577
 msgid "Task_AuthorRemainingL3"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L596
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L596
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:596
 msgid "Task_AuthorRemainingL3->Task_RunBuild"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L273
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L273
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:273
 msgid "Task_AuthorScenarios"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L292
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L292
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:292
 msgid "Task_AuthorScenarios->Task_AuthorBPMN"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L512
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L512
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:512
 msgid "Task_AuthorTerminology"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L532
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L532
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:532
 msgid "Task_AuthorTerminology->Task_AuthorCQL"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L545
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L545
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:545
 msgid "Task_AuthorTerminology->Task_ReviewTermBindings"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L646
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L646
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:646
 msgid "Task_CompleteL3"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L667
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L667
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:667
 msgid "Task_CompleteL3->End_L3"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L680
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L680
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:680
 msgid "Task_CompleteL3->Task_TranslateContent"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1054
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1054
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1054
 msgid "Task_CompleteTranslation"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1079
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1079
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1079
 msgid "Task_CompleteTranslation->End_Trans"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1066
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1066
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1066
 msgid "Task_CompleteTranslation->Task_ReviewTranslatedContent"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L939
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L939
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:939
 msgid "Task_CreatePubRequest"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L958
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L958
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:958
 msgid "Task_CreatePubRequest->Task_FinalBuild"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L913
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L913
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:913
 msgid "Task_CreateReleaseBranch"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L933
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L933
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:933
 msgid "Task_CreateReleaseBranch->Task_UpdateIGStatus"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L964
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L964
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:964
 msgid "Task_CreateReleaseTag"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L984
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L984
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:984
 msgid "Task_CreateReleaseTag->Task_VerifyAutomation"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L187
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L187
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:187
 msgid "Task_DefineDataElements"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L215
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L215
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:215
 msgid "Task_DefineRequirements"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L229
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L229
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:229
 msgid "Task_DefineRequirements->Task_DraftDAKComponents"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L181
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L181
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:181
 msgid "Task_DetailWorkflow"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L194
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L194
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:194
 msgid "Task_DevelopDecisionLogic"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L201
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L201
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:201
 msgid "Task_DevelopSchedulingLogic"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L222
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L222
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:222
 msgid "Task_DraftDAKComponents"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L311
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L311
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:311
 msgid "Task_DraftDAKComponents->Task_IncorporateFeedback"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L324
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L324
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:324
 msgid "Task_DraftDAKComponents->Task_ValidateClinical"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L91
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L91
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:91
 msgid "Task_EstablishProcess"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L111
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L111
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:111
 msgid "Task_EstablishProcess->Task_GatherDocs"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L951
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L951
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:951
 msgid "Task_FinalBuild"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L971
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L971
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:971
 msgid "Task_FinalBuild->Task_CreateReleaseTag"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L349
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L349
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:349
 msgid "Task_FinalizeL2"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L369
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L369
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:369
 msgid "Task_FinalizeL2->End_L2"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L382
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L382
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:382
 msgid "Task_FinalizeL2->Task_VerifyL2Input"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L602
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L602
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:602
 msgid "Task_FixIssues"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L633
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L633
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:633
 msgid "Task_FixIssues->GW_L3Done"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L78
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L78
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:78
 msgid "Task_FormTeam"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L98
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L98
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:98
 msgid "Task_FormTeam->Task_EstablishProcess"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L104
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L104
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:104
 msgid "Task_GatherDocs"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L124
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L124
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:124
 msgid "Task_GatherDocs->Task_PlanTimeline"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L405
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L405
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:405
 msgid "Task_GroundTruth"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L425
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L425
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:425
 msgid "Task_GroundTruth->Task_ProvideFeedback"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L247
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L247
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:247
 msgid "Task_IdentifyInterventions"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L267
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L267
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:267
 msgid "Task_IdentifyInterventions->Task_AuthorPersonas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L304
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L304
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:304
 msgid "Task_IncorporateFeedback"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L336
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L336
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:336
 msgid "Task_IncorporateFeedback->GW_MoreSprints"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L208
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L208
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:208
 msgid "Task_ListIndicators"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L698
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L698
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:698
 msgid "Task_MapToCommons"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L717
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L717
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:717
 msgid "Task_MapToCommons->Task_MapToStandards"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L711
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L711
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:711
 msgid "Task_MapToStandards"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L730
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L730
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:730
 msgid "Task_MapToStandards->Task_OnboardConcepts"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L723
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L723
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:723
 msgid "Task_OnboardConcepts"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L743
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L743
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:743
 msgid "Task_OnboardConcepts->End_Term"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L130
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L130
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:130
 msgid "Task_PlanConsultations"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L149
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L149
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:149
 msgid "Task_PlanConsultations->Task_AssignWork"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L117
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L117
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:117
 msgid "Task_PlanTimeline"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L137
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L137
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:137
 msgid "Task_PlanTimeline->Task_PlanConsultations"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L882
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L882
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:882
 msgid "Task_PrepareRelease"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L920
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L920
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:920
 msgid "Task_PrepareRelease->Task_CreateReleaseBranch"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L418
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L418
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:418
 msgid "Task_ProvideFeedback"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L444
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L444
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:444
 msgid "Task_ProvideFeedback->End_ClinReview"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L431
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L431
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:431
 msgid "Task_ProvideFeedback->Task_IncorporateFeedback"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L823
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L823
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:823
 msgid "Task_ReportIssues"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L863
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L863
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:863
 msgid "Task_ReportIssues->End_QC"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L850
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L850
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:850
 msgid "Task_ReportIssues->Task_FixIssues"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L990
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L990
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:990
 msgid "Task_RequestWHOUpdate"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1010
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1010
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1010
 msgid "Task_RequestWHOUpdate->Task_ResetToDraft"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1003
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1003
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1003
 msgid "Task_ResetToDraft"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1023
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1023
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1023
 msgid "Task_ResetToDraft->End_Pub"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L761
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L761
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:761
 msgid "Task_ReviewChecklistL1L2"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L779
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L779
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:779
 msgid "Task_ReviewChecklistL1L2->Task_ReviewChecklistL3L4"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L773
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L773
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:773
 msgid "Task_ReviewChecklistL3L4"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L792
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L792
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:792
 msgid "Task_ReviewChecklistL3L4->Task_ValidateConformance"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L168
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L168
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:168
 msgid "Task_ReviewL1"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L254
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L254
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:254
 msgid "Task_ReviewL1->Task_IdentifyInterventions"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L614
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L614
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:614
 msgid "Task_ReviewQA"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L767
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L767
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:767
 msgid "Task_ReviewQA->Task_ReviewChecklistL1L2"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L538
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L538
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:538
 msgid "Task_ReviewTermBindings"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L705
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L705
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:705
 msgid "Task_ReviewTermBindings->Task_MapToCommons"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L869
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L869
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:869
 msgid "Task_ReviewTranslatedContent"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L895
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L895
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:895
 msgid "Task_ReviewTranslatedContent->End_QC"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L590
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L590
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:590
 msgid "Task_RunBuild"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L608
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L608
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:608
 msgid "Task_RunBuild->Task_FixIssues"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L621
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L621
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:621
 msgid "Task_RunBuild->Task_ReviewQA"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L65
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L65
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:65
 msgid "Task_Scoping"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L85
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L85
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:85
 msgid "Task_Scoping->Task_FormTeam"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L462
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L462
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:462
 msgid "Task_SetupIG"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L481
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L481
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:481
 msgid "Task_SetupIG->Task_AuthorLogicalModels"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L798
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L798
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:798
 msgid "Task_TestFunctionality"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L817
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L817
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:817
 msgid "Task_TestFunctionality->GW_QCPass"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L673
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L673
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:673
 msgid "Task_TranslateContent"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1048
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1048
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1048
 msgid "Task_TranslateContent->Task_TranslateExamples"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1041
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1041
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1041
 msgid "Task_TranslateExamples"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1060
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1060
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1060
 msgid "Task_TranslateExamples->Task_CompleteTranslation"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L926
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L926
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:926
 msgid "Task_UpdateIGStatus"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L945
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L945
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:945
 msgid "Task_UpdateIGStatus->Task_CreatePubRequest"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L317
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L317
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:317
 msgid "Task_ValidateClinical"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L412
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L412
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:412
 msgid "Task_ValidateClinical->Task_GroundTruth"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L785
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L785
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:785
 msgid "Task_ValidateConformance"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L805
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L805
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:805
 msgid "Task_ValidateConformance->Task_TestFunctionality"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L977
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L977
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:977
 msgid "Task_VerifyAutomation"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L997
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L997
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:997
 msgid "Task_VerifyAutomation->Task_RequestWHOUpdate"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L375
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L375
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:375
 msgid "Task_VerifyL2Input"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L468
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L468
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:468
 msgid "Task_VerifyL2Input->Task_SetupIG"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L40
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L40
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:40
 msgid "Terminologist"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L739
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L739
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:739
 msgid "Terminology Complete"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L688
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L688
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:688
 msgid "Terminology Review Requested"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L800
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L800
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:800
 msgid "Test L3 functionality"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L153
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L153
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:153
 msgid "Test Scenarios"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L675
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L675
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:675
 msgid "Translate narrative and resource"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1075
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1075
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1075
 msgid "Translation Complete"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L55
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L55
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:55
 msgid "Translator"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L928
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L928
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:928
 msgid "Update IG status to active, set"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L75
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L75
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:75
 msgid "User Scenarios"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L787
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L787
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:787
 msgid "Validate artifact conformance (CRMI"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L319
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L319
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:319
 msgid "Validate DAK components against L1"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L954
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L954
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:954
 msgid "verify"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L979
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L979
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:979
 msgid "Verify automated publication"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L377
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L377
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:377
 msgid "Verify L2 input availability and"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L156
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L156
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:156
 msgid "Verify that digital systems correctly interpret and implement WHO clinical guidelines."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L1006
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L1006
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:1006
 msgid "version"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L885
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L885
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:885
 msgid "version number"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L929
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L929
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:929
 msgid "version, date"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L980
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L980
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:980
 msgid "workflow succeeded"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/L2_DAK_components_3x3_logoimage.svg#L159
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/L2_DAK_components_3x3_logoimage.svg#L159
 #. URL: http://smart.who.int/base/L2_DAK_components_3x3_logoimage.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/L2_DAK_components_3x3_logoimage.svg
 #: input/images/L2_DAK_components_3x3_logoimage.svg:159
 msgid "World Health Organization"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L656
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L656
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:656
 msgid "Yes"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L846
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L846
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:846
 msgid "Yes - approved"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/images/SGAuthoring.DAKLifecycle.svg#L345
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/images/SGAuthoring.DAKLifecycle.svg#L345
 #. URL: http://smart.who.int/base/SGAuthoring.DAKLifecycle.svg
 #. URL: https://WorldHealthOrganization.github.io/smart-base/SGAuthoring.DAKLifecycle.svg
 #: input/images/SGAuthoring.DAKLifecycle.svg:345

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.md:1
 msgid "Capability to create FHIR ActorDefinitions from L2 personas, reusing existing definitions from the Commons repository."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.md:7
 msgid "Phase: L3 FHIR Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorActorDefinitions.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.md:1
 msgid "Capability to create BPMN 2.0 business process diagrams for DAK workflows."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.md:7
 msgid "Phase: L2 DAK Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorBusinessProcesses.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorCQL.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorCQL.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCQL.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCQL.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorCQL.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorCQL.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCQL.md:1
 msgid "Capability to write Clinical Quality Language (CQL) for decision logic, scheduling logic, and indicator calculations."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCQL.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCQL.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorCQL.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorCQL.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCQL.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCQL.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCQL.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorCQL.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorCQL.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCQL.md:7
 msgid "Phase: L3 FHIR Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCQL.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCQL.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorCQL.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorCQL.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCQL.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorCodeSystems.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorCodeSystems.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCodeSystems.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCodeSystems.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorCodeSystems.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorCodeSystems.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCodeSystems.md:1
 msgid "Capability to create and maintain FHIR CodeSystem resources."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCodeSystems.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCodeSystems.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorCodeSystems.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorCodeSystems.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCodeSystems.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCodeSystems.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCodeSystems.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorCodeSystems.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorCodeSystems.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCodeSystems.md:7
 msgid "Phase: L3 FHIR Authoring (Terminology)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCodeSystems.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCodeSystems.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorCodeSystems.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorCodeSystems.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorCodeSystems.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorConceptMaps.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorConceptMaps.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorConceptMaps.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorConceptMaps.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorConceptMaps.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorConceptMaps.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorConceptMaps.md:1
 msgid "Capability to create FHIR ConceptMap resources for cross-terminology mappings."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorConceptMaps.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorConceptMaps.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorConceptMaps.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorConceptMaps.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorConceptMaps.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorConceptMaps.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorConceptMaps.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorConceptMaps.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorConceptMaps.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorConceptMaps.md:7
 msgid "Phase: L3 FHIR Authoring (Terminology)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorConceptMaps.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorConceptMaps.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorConceptMaps.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorConceptMaps.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorConceptMaps.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorDataDictionary.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorDataDictionary.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDataDictionary.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDataDictionary.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorDataDictionary.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorDataDictionary.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDataDictionary.md:1
 msgid "Capability to define core data elements and map to standard terminologies."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDataDictionary.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDataDictionary.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorDataDictionary.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorDataDictionary.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDataDictionary.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDataDictionary.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDataDictionary.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorDataDictionary.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorDataDictionary.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDataDictionary.md:7
 msgid "Phase: L2 DAK Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDataDictionary.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDataDictionary.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorDataDictionary.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorDataDictionary.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDataDictionary.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.md:1
 msgid "Capability to develop decision-support logic tables following the DMN standard."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.md:7
 msgid "Phase: L2 DAK Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorDecisionLogic.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.md:1
 msgid "Capability to create ExampleScenario resources from L2 user scenarios."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.md:7
 msgid "Phase: L3 FHIR Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorExampleScenarios.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.md:1
 msgid "Capability to create FHIR profiles (StructureDefinitions) constraining base FHIR resources."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.md:7
 msgid "Phase: L3 FHIR Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRProfiles.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.md:1
 msgid "Capability to create FHIR Requirements resources from L2 functional and non-functional requirements."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.md:7
 msgid "Phase: L3 FHIR Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFHIRRequirements.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.md:1
 msgid "Capability to define high-level functional and non-functional requirements linked to personas and business processes."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.md:7
 msgid "Phase: L2 DAK Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorFunctionalRequirements.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorIndicators.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorIndicators.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorIndicators.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorIndicators.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorIndicators.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorIndicators.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorIndicators.md:1
 msgid "Capability to define indicators and performance metrics with numerator/denominator specifications."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorIndicators.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorIndicators.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorIndicators.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorIndicators.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorIndicators.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorIndicators.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorIndicators.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorIndicators.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorIndicators.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorIndicators.md:7
 msgid "Phase: L2 DAK Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorIndicators.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorIndicators.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorIndicators.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorIndicators.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorIndicators.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorLogicalModels.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorLogicalModels.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorLogicalModels.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorLogicalModels.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorLogicalModels.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorLogicalModels.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorLogicalModels.md:1
 msgid "Capability to create FHIR logical models (StructureDefinitions) from L2 data dictionaries."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorLogicalModels.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorLogicalModels.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorLogicalModels.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorLogicalModels.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorLogicalModels.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorLogicalModels.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorLogicalModels.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorLogicalModels.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorLogicalModels.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorLogicalModels.md:7
 msgid "Phase: L3 FHIR Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorLogicalModels.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorLogicalModels.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorLogicalModels.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorLogicalModels.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorLogicalModels.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorMeasures.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorMeasures.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorMeasures.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorMeasures.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorMeasures.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorMeasures.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorMeasures.md:1
 msgid "Capability to create FHIR Measure resources from L2 indicators."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorMeasures.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorMeasures.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorMeasures.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorMeasures.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorMeasures.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorMeasures.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorMeasures.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorMeasures.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorMeasures.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorMeasures.md:7
 msgid "Phase: L3 FHIR Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorMeasures.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorMeasures.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorMeasures.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorMeasures.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorMeasures.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorPersonas.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorPersonas.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPersonas.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPersonas.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorPersonas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorPersonas.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPersonas.md:1
 msgid "Capability to define generic personas based on task-shifting guidelines and ground-truthing interviews."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPersonas.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPersonas.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorPersonas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorPersonas.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPersonas.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPersonas.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPersonas.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorPersonas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorPersonas.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPersonas.md:7
 msgid "Phase: L2 DAK Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPersonas.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPersonas.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorPersonas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorPersonas.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPersonas.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.md:1
 msgid "Capability to create FHIR PlanDefinitions for business processes and decision tables."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.md:7
 msgid "Phase: L3 FHIR Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorPlanDefinitions.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.md:1
 msgid "Capability to create FHIR Questionnaire resources aligned with L2 forms and data collection needs."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.md:7
 msgid "Phase: L3 FHIR Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorQuestionnaires.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.md:1
 msgid "Capability to develop scheduling logic tables following the DMN standard."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.md:7
 msgid "Phase: L2 DAK Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorSchedulingLogic.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorStructureMaps.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorStructureMaps.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorStructureMaps.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorStructureMaps.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorStructureMaps.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorStructureMaps.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorStructureMaps.md:1
 msgid "Capability to create FHIR StructureMaps for data extraction from QuestionnaireResponses to FHIR resources."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorStructureMaps.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorStructureMaps.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorStructureMaps.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorStructureMaps.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorStructureMaps.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorStructureMaps.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorStructureMaps.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorStructureMaps.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorStructureMaps.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorStructureMaps.md:7
 msgid "Phase: L3 FHIR Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorStructureMaps.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorStructureMaps.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorStructureMaps.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorStructureMaps.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorStructureMaps.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorTestCases.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorTestCases.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorTestCases.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorTestCases.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorTestCases.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorTestCases.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorTestCases.md:1
 msgid "Capability to create TestPlan, TestScript, and example instances for validation of L3 artifacts."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorTestCases.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorTestCases.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorTestCases.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorTestCases.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorTestCases.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorTestCases.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorTestCases.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorTestCases.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorTestCases.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorTestCases.md:7
 msgid "Phase: L3 FHIR Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorTestCases.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorTestCases.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorTestCases.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorTestCases.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorTestCases.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorUserScenarios.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorUserScenarios.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorUserScenarios.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorUserScenarios.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorUserScenarios.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorUserScenarios.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorUserScenarios.md:1
 msgid "Capability to create user scenario narratives depicting typical interactions in health programme workflows."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorUserScenarios.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorUserScenarios.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorUserScenarios.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorUserScenarios.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorUserScenarios.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorUserScenarios.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorUserScenarios.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorUserScenarios.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorUserScenarios.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorUserScenarios.md:7
 msgid "Phase: L2 DAK Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorUserScenarios.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorUserScenarios.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorUserScenarios.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorUserScenarios.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorUserScenarios.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorValueSets.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.AuthorValueSets.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorValueSets.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorValueSets.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorValueSets.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorValueSets.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorValueSets.md:1
 msgid "Capability to create and maintain FHIR ValueSet resources with appropriate terminology bindings."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorValueSets.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorValueSets.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorValueSets.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorValueSets.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorValueSets.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorValueSets.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorValueSets.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorValueSets.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorValueSets.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorValueSets.md:7
 msgid "Phase: L3 FHIR Authoring (Terminology)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorValueSets.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.AuthorValueSets.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.AuthorValueSets.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.AuthorValueSets.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.AuthorValueSets.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.BuildIG.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.BuildIG.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,35 +16,35 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.BuildIG.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.BuildIG.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md:1
 msgid "Capability to run the FHIR IG Publisher build process and verify output."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.BuildIG.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.BuildIG.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md#L8
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md#L8
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.BuildIG.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.BuildIG.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md:8
 msgid "Phase: Publication"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md#L6
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md#L6
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.BuildIG.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.BuildIG.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md:6
 msgid "SGAuthoring.Persona.FHIRModeller"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.BuildIG.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.BuildIG.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.BuildIG.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ConfigureIG.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ConfigureIG.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ConfigureIG.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ConfigureIG.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ConfigureIG.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ConfigureIG.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ConfigureIG.md:1
 msgid "Capability to set up and configure a FHIR Implementation Guide (sushi-config, canonical URL, packages)."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ConfigureIG.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ConfigureIG.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ConfigureIG.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ConfigureIG.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ConfigureIG.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ConfigureIG.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ConfigureIG.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ConfigureIG.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ConfigureIG.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ConfigureIG.md:7
 msgid "Phase: Publication"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ConfigureIG.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ConfigureIG.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ConfigureIG.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ConfigureIG.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ConfigureIG.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.md:1
 msgid "Capability to interpret clinical recommendations from L1 source documents with domain expertise."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.md:7
 msgid "Phase: Planning / L2 Preparation"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.InterpretClinicalRecommendations.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ManageGovernance.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ManageGovernance.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ManageGovernance.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ManageGovernance.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ManageGovernance.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ManageGovernance.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ManageGovernance.md:1
 msgid "Capability to manage cross-IG governance for shared artifacts including common personas, terminology, and libraries."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ManageGovernance.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ManageGovernance.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ManageGovernance.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ManageGovernance.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ManageGovernance.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ManageGovernance.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ManageGovernance.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ManageGovernance.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ManageGovernance.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ManageGovernance.md:7
 msgid "Phase: Publication"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ManageGovernance.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ManageGovernance.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ManageGovernance.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ManageGovernance.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ManageGovernance.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ManageReleases.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ManageReleases.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ManageReleases.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ManageReleases.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ManageReleases.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ManageReleases.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ManageReleases.md:1
 msgid "Capability to manage versioning, publication-request.json, release tags, and publication workflow."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ManageReleases.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ManageReleases.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ManageReleases.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ManageReleases.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ManageReleases.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ManageReleases.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ManageReleases.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ManageReleases.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ManageReleases.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ManageReleases.md:7
 msgid "Phase: Publication"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ManageReleases.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ManageReleases.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ManageReleases.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ManageReleases.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ManageReleases.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ManageStakeholders.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ManageStakeholders.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ManageStakeholders.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ManageStakeholders.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ManageStakeholders.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ManageStakeholders.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ManageStakeholders.md:1
 msgid "Capability to engage SMEs, coordinate consultations, and manage the RASCI matrix for DAK development."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ManageStakeholders.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ManageStakeholders.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ManageStakeholders.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ManageStakeholders.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ManageStakeholders.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ManageStakeholders.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ManageStakeholders.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ManageStakeholders.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ManageStakeholders.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ManageStakeholders.md:7
 msgid "Phase: Planning / Ongoing"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ManageStakeholders.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ManageStakeholders.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ManageStakeholders.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ManageStakeholders.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ManageStakeholders.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.MapConcepts.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.MapConcepts.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.MapConcepts.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.MapConcepts.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.MapConcepts.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.MapConcepts.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.MapConcepts.md:1
 msgid "Capability to map data elements to WHO Commons dictionary, ICD-11, SNOMED CT, LOINC, and other standard terminologies."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.MapConcepts.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.MapConcepts.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.MapConcepts.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.MapConcepts.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.MapConcepts.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.MapConcepts.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.MapConcepts.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.MapConcepts.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.MapConcepts.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.MapConcepts.md:7
 msgid "Phase: L3 FHIR Authoring (Terminology)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.MapConcepts.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.MapConcepts.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.MapConcepts.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.MapConcepts.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.MapConcepts.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.PlanIterations.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.PlanIterations.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.PlanIterations.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.PlanIterations.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.PlanIterations.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.PlanIterations.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.PlanIterations.md:1
 msgid "Capability to plan sprint iterations, maintain the DAK backlog, draft the project roadmap, and facilitate retrospectives."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.PlanIterations.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.PlanIterations.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.PlanIterations.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.PlanIterations.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.PlanIterations.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.PlanIterations.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.PlanIterations.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.PlanIterations.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.PlanIterations.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.PlanIterations.md:7
 msgid "Phase: Planning / Ongoing"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.PlanIterations.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.PlanIterations.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.PlanIterations.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.PlanIterations.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.PlanIterations.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.md:1
 msgid "Capability to review and formally approve SMART Guidelines content at decision gates in the authoring lifecycle."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.md:7
 msgid "Phase: Content Approval"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewAndApproveContent.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ReviewChecklist.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ReviewChecklist.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewChecklist.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewChecklist.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewChecklist.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewChecklist.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewChecklist.md:1
 msgid "Capability to review the SMART Guidelines publication checklist across L1-L4 layers and global requirements."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewChecklist.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewChecklist.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewChecklist.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewChecklist.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewChecklist.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewChecklist.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewChecklist.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewChecklist.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewChecklist.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewChecklist.md:7
 msgid "Phase: Quality Control"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewChecklist.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewChecklist.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewChecklist.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewChecklist.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewChecklist.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,42 +16,42 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md:1
 msgid "Capability to review WHO L1 narrative guidelines and normative products for accuracy and completeness."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md#L9
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md#L9
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md:9
 msgid "Phase: Planning / L2 Preparation"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md:5
 msgid "SGAuthoring.Persona.BusinessAnalyst"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md#L6
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md#L6
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md:6
 msgid "SGAuthoring.Persona.ClinicalSME"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewL1Guidelines.md:7

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ReviewTerminology.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ReviewTerminology.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTerminology.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTerminology.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewTerminology.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewTerminology.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTerminology.md:1
 msgid "Capability to review and validate terminology bindings, code systems, and value sets for correctness and completeness."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTerminology.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTerminology.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewTerminology.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewTerminology.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTerminology.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTerminology.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTerminology.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewTerminology.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewTerminology.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTerminology.md:7
 msgid "Phase: L3 FHIR Authoring (Terminology)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTerminology.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTerminology.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewTerminology.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewTerminology.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTerminology.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ReviewTranslations.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ReviewTranslations.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTranslations.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTranslations.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewTranslations.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewTranslations.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTranslations.md:1
 msgid "Capability to review translated content for accuracy and completeness."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTranslations.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTranslations.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewTranslations.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewTranslations.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTranslations.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTranslations.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTranslations.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewTranslations.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewTranslations.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTranslations.md:7
 msgid "Phase: Translation"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTranslations.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTranslations.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ReviewTranslations.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ReviewTranslations.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ReviewTranslations.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.RunQAChecks.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.RunQAChecks.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.RunQAChecks.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.RunQAChecks.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.RunQAChecks.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.RunQAChecks.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.RunQAChecks.md:1
 msgid "Capability to run and interpret IG Publisher QA validation reports."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.RunQAChecks.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.RunQAChecks.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.RunQAChecks.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.RunQAChecks.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.RunQAChecks.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.RunQAChecks.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.RunQAChecks.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.RunQAChecks.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.RunQAChecks.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.RunQAChecks.md:7
 msgid "Phase: Quality Control"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.RunQAChecks.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.RunQAChecks.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.RunQAChecks.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.RunQAChecks.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.RunQAChecks.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ScopeDAK.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ScopeDAK.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ScopeDAK.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ScopeDAK.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ScopeDAK.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ScopeDAK.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ScopeDAK.md:1
 msgid "Capability to define DAK scope, identify source documents, and establish the development process and governance."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ScopeDAK.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ScopeDAK.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ScopeDAK.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ScopeDAK.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ScopeDAK.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ScopeDAK.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ScopeDAK.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ScopeDAK.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ScopeDAK.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ScopeDAK.md:7
 msgid "Phase: Planning"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ScopeDAK.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ScopeDAK.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ScopeDAK.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ScopeDAK.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ScopeDAK.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.TranslateContent.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.TranslateContent.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.TranslateContent.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.TranslateContent.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.TranslateContent.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.TranslateContent.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.TranslateContent.md:1
 msgid "Capability to translate IG content across UN languages."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.TranslateContent.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.TranslateContent.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.TranslateContent.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.TranslateContent.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.TranslateContent.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.TranslateContent.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.TranslateContent.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.TranslateContent.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.TranslateContent.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.TranslateContent.md:7
 msgid "Phase: Translation"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.TranslateContent.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.TranslateContent.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.TranslateContent.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.TranslateContent.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.TranslateContent.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.md:1
 msgid "Capability to verify conformance to CRMI Shareable, Publishable, Computable, and Executable profiles."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.md#L7
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.md:7
 msgid "Phase: Quality Control"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ValidateArtifactConformance.md:5

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ValidateDAKContent.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ValidateDAKContent.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,35 +16,35 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ValidateDAKContent.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ValidateDAKContent.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md:1
 msgid "Capability to review and validate DAK components against L1 source documents and for cross-component consistency."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ValidateDAKContent.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ValidateDAKContent.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md#L8
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md#L8
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ValidateDAKContent.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ValidateDAKContent.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md:8
 msgid "Phase: L2 DAK Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ValidateDAKContent.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ValidateDAKContent.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md:5
 msgid "SGAuthoring.Persona.BusinessAnalyst"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md#L6
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md#L6
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ValidateDAKContent.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ValidateDAKContent.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ValidateDAKContent.md:6

--- a/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ValidateL3Functionality.pot
+++ b/input/pagecontent/translations/Requirements-SGAuthoring.Skills.ValidateL3Functionality.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,35 +16,35 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md#L1
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ValidateL3Functionality.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ValidateL3Functionality.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md:1
 msgid "Capability to test StructureMap extraction, CQL execution, and measure calculation using reference tooling."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md#L3
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ValidateL3Functionality.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ValidateL3Functionality.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md:3
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md#L8
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md#L8
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ValidateL3Functionality.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ValidateL3Functionality.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md:8
 msgid "Phase: Quality Control"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md#L6
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md#L6
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ValidateL3Functionality.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ValidateL3Functionality.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md:6
 msgid "SGAuthoring.Persona.FHIRModeller"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md#L5
 #. URL: http://smart.who.int/base/Requirements-SGAuthoring.Skills.ValidateL3Functionality.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/Requirements-SGAuthoring.Skills.ValidateL3Functionality.html
 #: input/pagecontent/Requirements-SGAuthoring.Skills.ValidateL3Functionality.md:5

--- a/input/pagecontent/translations/authoring-personas.pot
+++ b/input/pagecontent/translations/authoring-personas.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,14 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L28
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L28
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L30
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L31
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L32
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L33
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L34
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L35
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L30
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L31
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L32
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L33
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L34
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L35
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:28
 #: input/pagecontent/authoring-personas.md:30
@@ -35,347 +35,347 @@ msgstr ""
 msgid "A/R"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L18
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L18
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:18
 msgid "Approves content at decision gates (L2→L3, draft→publication)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L1
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:1
 msgid "Authoring Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L14
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L14
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:14
 msgid "Authors L2 DAK components (BPMN, data dictionary, logic, requirements)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L15
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L15
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:15
 msgid "Authors L3 FHIR artifacts from L2 specifications"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L14
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L14
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L26
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L26
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:14
 #: input/pagecontent/authoring-personas.md:26
 msgid "Business Analyst"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L30
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L30
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:30
 msgid "Clinical Review"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L13
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L13
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L26
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L26
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:13
 #: input/pagecontent/authoring-personas.md:26
 msgid "Clinical SME"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L33
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L33
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:33
 msgid "Content Approval"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L18
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L18
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L26
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L26
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:18
 #: input/pagecontent/authoring-personas.md:26
 msgid "Content Reviewer"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L12
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L12
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:12
 msgid "Coordinates DAK work and performs first-pass content review"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L9
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L9
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:9
 msgid "Description"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L15
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L15
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L26
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L26
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:15
 #: input/pagecontent/authoring-personas.md:26
 msgid "FHIR Modeller"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L14
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L14
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L29
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L29
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:14
 #: input/pagecontent/authoring-personas.md:29
 msgid "L2 Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L13
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L13
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:13
 msgid "L2 Review"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L15
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L15
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L31
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L31
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:15
 #: input/pagecontent/authoring-personas.md:31
 msgid "L3 Authoring"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L16
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L16
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:16
 msgid "L3 Authoring, Governance"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L37
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L37
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:37
 msgid "Legend: R = Responsible, A = Accountable, S = Support, C = Consulted, I = Informed"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L11
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L11
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:11
 msgid "Manages DAK scope, timeline, resources, and stakeholder engagement"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L19
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L19
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:19
 msgid "Manages IG configuration, builds, versioning, and releases"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L16
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L16
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:16
 msgid "Manages terminology, concept mappings, and WHO Commons dictionary"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L9
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L9
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:9
 msgid "Persona"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L7
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:7
 msgid "Persona Definitions"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L26
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L26
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:26
 msgid "Phase"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L11
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L11
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L28
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L28
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:11
 #: input/pagecontent/authoring-personas.md:28
 msgid "Planning"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L12
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L12
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:12
 msgid "Planning, L2 Review"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L9
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L9
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:9
 msgid "Primary Phase"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L11
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L11
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L26
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L26
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:11
 #: input/pagecontent/authoring-personas.md:26
 msgid "Programme Manager"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L19
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L19
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L35
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L35
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:19
 #: input/pagecontent/authoring-personas.md:35
 msgid "Publication"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L19
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L19
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L26
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L26
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:19
 #: input/pagecontent/authoring-personas.md:26
 msgid "Publication Manager"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L17
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L17
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L26
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L26
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:17
 #: input/pagecontent/authoring-personas.md:26
 msgid "QC Reviewer"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L17
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L17
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L32
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L32
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:17
 #: input/pagecontent/authoring-personas.md:32
 msgid "Quality Control"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L22
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L22
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:22
 msgid "RASCI Matrix"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L39
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L39
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:39
 msgid "Relationship to DAK Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L18
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L18
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:18
 msgid "Review / Approval"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L17
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L17
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:17
 msgid "Reviews publication readiness using checklists and QA reports"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L3
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:3
 msgid "SMART Guidelines and Digital Adaptation Kits (DAKs) are authored by multidisciplinary teams. The authoring personas defined here represent the roles involved in the authoring, review, and publication lifecycle — distinct from the clinical/health personas defined within a DAK itself."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L12
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L12
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L26
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L26
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:12
 #: input/pagecontent/authoring-personas.md:26
 msgid "Technical Officer"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L16
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L16
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L26
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L26
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:16
 #: input/pagecontent/authoring-personas.md:26
 msgid "Terminologist"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L24
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L24
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:24
 msgid "The IG Starter Kit recommends defining a RASCI (Responsible, Accountable, Support, Consulted, Informed) matrix. Below is a reference matrix mapping personas to lifecycle phases:"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L41
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L41
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:41
 msgid "These authoring personas should not be confused with DAK component 2 \"Generic Personas\" which represent end users of healthcare systems (e.g. Community Health Worker, Healthcare Provider). The authoring personas represent the people who create the SMART Guidelines, while DAK personas represent the people who use the resulting digital systems."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L5
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:5
 msgid "These personas are derived from the WHO SMART IG Starter Kit guidance on DAK development teams, authoring processes, and community of practice workstreams."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L20
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L20
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:20
 msgid "Translates IG content across UN languages"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L20
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L20
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L34
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L34
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:20
 #: input/pagecontent/authoring-personas.md:34
 msgid "Translation"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L20
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L20
 #. URL: http://smart.who.int/base/authoring-personas.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L26
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L26
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:20
 #: input/pagecontent/authoring-personas.md:26
 msgid "Translator"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-personas.md#L13
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-personas.md#L13
 #. URL: http://smart.who.int/base/authoring-personas.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-personas.html
 #: input/pagecontent/authoring-personas.md:13

--- a/input/pagecontent/translations/authoring-process.pot
+++ b/input/pagecontent/translations/authoring-process.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,525 +16,525 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L64
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L64
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:64
 msgid "ActorDefinitions (reusing Commons repository)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L27
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L27
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:27
 msgid "Assign work — Begin sprint cycle"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L37
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L37
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:37
 msgid "Author BPMN business processes (Component 4)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L35
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L35
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:35
 msgid "Author generic personas (Component 2)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L59
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L59
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:59
 msgid "Author L3 artifacts in recommended sequence:"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L36
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L36
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:36
 msgid "Author user scenarios (Component 3)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L1
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:1
 msgid "Authoring Process"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L104
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L104
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:104
 msgid "BPMN Process Diagram"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L49
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L49
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:49
 msgid "Clinical Review (Clinical SME)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L61
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L61
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:61
 msgid "CodeSystems, ValueSets, ConceptMaps (with Terminologist)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L62
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L62
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:62
 msgid "CQL (decision logic, scheduling, indicators)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L89
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L89
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:89
 msgid "Create example resources per UN language"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L99
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L99
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:99
 msgid "Create GitHub release and tag (vX.Y.Z) — triggers automated workflow"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L97
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L97
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:97
 msgid "Create publication-request.json"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L81
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L81
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:81
 msgid "Decision gate: Publication ready?"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L40
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L40
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:40
 msgid "Define core data elements (Component 5)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L44
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L44
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:44
 msgid "Define functional/non-functional requirements (Component 9)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L41
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L41
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:41
 msgid "Develop decision-support logic (Component 6)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L42
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L42
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:42
 msgid "Develop scheduling logic (Component 7)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L39
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L39
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:39
 msgid "Draft detailed workflow annotations"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L23
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L23
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:23
 msgid "Establish process — Select Agile/Scrum methodology and project tooling"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L38
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L38
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:38
 msgid "For each business process:"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L22
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L22
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:22
 msgid "Form team — Assemble DAK development team (<10 people), define RASCI matrix"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L24
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L24
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:24
 msgid "Gather source documents — Collect WHO guidelines, registers, policy documents"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L52
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L52
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:52
 msgid "Ground-truth with field practice (country visits, facility interviews)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L34
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L34
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:34
 msgid "Identify health interventions and recommendations (Component 1)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L47
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L47
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:47
 msgid "Incorporate feedback and begin next sprint"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L7
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:7
 msgid "Lifecycle Overview"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L43
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L43
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:43
 msgid "List indicators and metrics (Component 8)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L60
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L60
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:60
 msgid "Logical Models → Profiles → Questionnaires → StructureMaps"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L71
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L71
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:71
 msgid "Map concepts to WHO Commons dictionary"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L72
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L72
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:72
 msgid "Map to ICD-11, SNOMED CT, LOINC"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L65
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L65
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:65
 msgid "Measures, Requirements, Scenarios, Tests"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L82
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L82
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:82
 msgid "No: Report issues to FHIR Modeller for resolution → re-review"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L73
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L73
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:73
 msgid "Onboard new concepts through governance process"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L95
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L95
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:95
 msgid "Optionally create release-candidate branch"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L19
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L19
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:19
 msgid "Phase 1: Planning (Programme Manager)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L29
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L29
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:29
 msgid "Phase 2a: L2 DAK Authoring (Business Analyst, iterative)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L55
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L55
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:55
 msgid "Phase 2b: L3 FHIR Authoring (FHIR Modeller)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L75
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L75
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:75
 msgid "Phase 3: Quality Control (QC Reviewer)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L92
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L92
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:92
 msgid "Phase 4: Publication (Publication Manager)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L26
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L26
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:26
 msgid "Plan consultations — Schedule SME consultation format and frequency"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L25
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L25
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:25
 msgid "Plan timeline — Draft project roadmap, create backlog, set sprint cadence"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L63
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L63
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:63
 msgid "PlanDefinitions (processes, decision tables)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L53
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L53
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:53
 msgid "Provide clinical feedback and identify gaps"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L101
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L101
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:101
 msgid "Request WHO team to update smart.who.int"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L102
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L102
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:102
 msgid "Reset main to draft, update version for next cycle"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L94
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L94
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:94
 msgid "Review changes since last release, determine version number"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L78
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L78
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:78
 msgid "Review checklist items across L1, L2, L3, L4, Global sections"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L33
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L33
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:33
 msgid "Review L1 source documents for current sprint scope"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L77
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L77
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:77
 msgid "Review QA report (qa.html) from IG Publisher"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L70
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L70
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:70
 msgid "Review terminology bindings and code systems"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L84
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L84
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:84
 msgid "Review translated content for completeness"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L98
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L98
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:98
 msgid "Run final build and verify"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L66
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L66
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:66
 msgid "Run IG Publisher build and fix issues iteratively"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L21
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L21
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:21
 msgid "Scoping — Define DAK purpose, target audience, and gaps"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L58
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L58
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:58
 msgid "Set up IG repository from smart-ig-empty template"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L45
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L45
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:45
 msgid "Streamline all DAK components for cross-component consistency"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L90
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L90
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:90
 msgid "Submit translations for QC review"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L68
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L68
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:68
 msgid "Terminology Management (Terminologist, concurrent with L3)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L80
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L80
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:80
 msgid "Test L3 functionality (StructureMaps, CQL, Measures)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L106
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L106
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:106
 msgid "The formal BPMN 2.0 process diagram is available at: SGAuthoring.DAKLifecycle.bpmn"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L31
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L31
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:31
 msgid "The L2 authoring follows an iterative sprint cycle of Fill → Validate → Incorporate:"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L5
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:5
 msgid "The process is based on the WHO SMART IG Starter Kit guidance."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L3
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:3
 msgid "The SMART Guidelines authoring lifecycle encompasses DAK development, L3 FHIR authoring, quality control, translation, and publication. This process is defined as a BPMN 2.0 collaboration diagram with swimlanes for each authoring persona."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L108
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L108
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:108
 msgid "This diagram models the full lifecycle as a collaboration with swimlanes for each authoring persona, including message flows between participants for handoffs (e.g. Business Analyst → Clinical SME for validation, QC Reviewer → Publication Manager for approval)."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L88
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L88
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:88
 msgid "Translate narrative and resource metadata"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L86
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L86
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:86
 msgid "Translation (Translator, concurrent with QC)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L96
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L96
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:96
 msgid "Update IG status — status=active, version=X.Y.Z, releaseLabel=release"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L79
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L79
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:79
 msgid "Validate artifact conformance to CRMI profiles"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L51
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L51
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:51
 msgid "Validate DAK components against L1 recommendations"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L46
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L46
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:46
 msgid "Validate with SMEs (Clinical SME review)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L100
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L100
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:100
 msgid "Verify automated publication succeeded (sitepreview)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L57
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L57
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:57
 msgid "Verify L2 input availability and consistency"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-process.md#L83
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-process.md#L83
 #. URL: http://smart.who.int/base/authoring-process.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-process.html
 #: input/pagecontent/authoring-process.md:83

--- a/input/pagecontent/translations/authoring-skills.pot
+++ b/input/pagecontent/translations/authoring-skills.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,36 +16,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L105
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L105
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:105
 msgid "As part of the BPMN authoring and review process, every innermost swimlane in a BPMN diagram SHALL correspond to an ActorDefinition resource. The  skill includes a  command that checks this automatically."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L1
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L1
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:1
 msgid "Authoring Skills"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L103
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L103
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:103
 msgid "BPMN Swimlane Validation"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L31
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L31
 #. URL: http://smart.who.int/base/authoring-skills.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L32
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L33
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L34
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L35
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L36
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L37
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L95
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L32
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L33
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L34
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L35
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L36
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L37
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L95
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:31
 #: input/pagecontent/authoring-skills.md:32
@@ -58,501 +58,501 @@ msgstr ""
 msgid "Business Analyst"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L30
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L30
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:30
 msgid "Business Analyst, Clinical SME"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L49
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L49
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:49
 msgid "Can author actor definitions"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L32
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L32
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:32
 msgid "Can author business processes"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L60
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L60
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:60
 msgid "Can author code systems"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L62
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L62
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:62
 msgid "Can author concept maps"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L46
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L46
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:46
 msgid "Can author CQL"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L33
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L33
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:33
 msgid "Can author data dictionary"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L34
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L34
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:34
 msgid "Can author decision-support logic"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L50
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L50
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:50
 msgid "Can author example scenarios"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L44
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L44
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:44
 msgid "Can author FHIR profiles"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L52
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L52
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:52
 msgid "Can author FHIR requirements"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L37
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L37
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:37
 msgid "Can author functional requirements"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L36
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L36
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:36
 msgid "Can author indicators"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L43
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L43
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:43
 msgid "Can author logical models"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L51
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L51
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:51
 msgid "Can author measures"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L30
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L30
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:30
 msgid "Can author personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L48
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L48
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:48
 msgid "Can author plan definitions"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L45
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L45
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:45
 msgid "Can author questionnaires"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L35
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L35
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:35
 msgid "Can author scheduling logic"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L47
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L47
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:47
 msgid "Can author structure maps"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L53
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L53
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:53
 msgid "Can author test cases"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L31
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L31
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:31
 msgid "Can author user scenarios"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L61
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L61
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:61
 msgid "Can author value sets"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L76
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L76
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:76
 msgid "Can build IG"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L75
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L75
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:75
 msgid "Can configure IG"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L25
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L25
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:25
 msgid "Can interpret clinical recommendations"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L78
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L78
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:78
 msgid "Can manage governance"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L77
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L77
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:77
 msgid "Can manage releases"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L18
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L18
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:18
 msgid "Can manage stakeholders"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L59
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L59
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:59
 msgid "Can map concepts"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L19
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L19
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:19
 msgid "Can plan iterations"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L12
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L12
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:12
 msgid "Can review and approve content"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L68
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L68
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:68
 msgid "Can review checklist"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L24
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L24
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:24
 msgid "Can review L1 guidelines"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L58
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L58
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:58
 msgid "Can review terminology"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L84
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L84
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:84
 msgid "Can review translations"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L67
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L67
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:67
 msgid "Can run QA checks"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L17
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L17
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:17
 msgid "Can scope DAK"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L83
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L83
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:83
 msgid "Can translate content"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L69
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L69
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:69
 msgid "Can validate artifact conformance"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L38
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L38
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:38
 msgid "Can validate DAK content"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L70
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L70
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:70
 msgid "Can validate L3 functionality"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L94
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L94
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:94
 msgid "Clinical SME"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L25
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L25
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:25
 msgid "Clinical SME, Technical Officer"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L99
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L99
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:99
 msgid "Content Approval at decision gates"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L9
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L9
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:9
 msgid "Content Review Skills"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L12
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L12
 #. URL: http://smart.who.int/base/authoring-skills.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L99
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L99
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:12
 #: input/pagecontent/authoring-skills.md:99
 msgid "Content Reviewer"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L110
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L110
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:110
 msgid "Correcting a typo in the swimlane name"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L49
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L49
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:49
 msgid "Create ActorDefinitions, reusing Commons repository"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L60
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L60
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:60
 msgid "Create and maintain FHIR CodeSystem resources"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L61
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L61
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:61
 msgid "Create and maintain FHIR ValueSet resources"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L32
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L32
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:32
 msgid "Create BPMN 2.0 business process diagrams"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L50
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L50
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:50
 msgid "Create ExampleScenario resources"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L62
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L62
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:62
 msgid "Create FHIR ConceptMap resources"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L43
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L43
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:43
 msgid "Create FHIR logical models from L2 data dictionaries"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L51
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L51
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:51
 msgid "Create FHIR Measure resources from L2 indicators"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L44
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L44
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:44
 msgid "Create FHIR profiles constraining base resources"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L45
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L45
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:45
 msgid "Create FHIR Questionnaire resources"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L52
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L52
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:52
 msgid "Create FHIR Requirements resources"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L47
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L47
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:47
 msgid "Create FHIR StructureMaps for data extraction"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L48
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L48
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:48
 msgid "Create PlanDefinitions for processes and decision tables"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L53
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L53
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:53
 msgid "Create TestPlan, TestScript, and example instances"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L31
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L31
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:31
 msgid "Create user scenario narratives"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L109
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L109
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:109
 msgid "Creating a new ActorDefinition in this IG"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L33
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L33
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:33
 msgid "Define core data elements with terminology mappings"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L17
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L17
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:17
 msgid "Define DAK scope, source documents, and development process"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L37
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L37
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:37
 msgid "Define functional and non-functional requirements"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L30
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L30
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:30
 msgid "Define generic personas from guidelines and ground-truthing"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L36
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L36
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:36
 msgid "Define indicators with numerator/denominator"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L10
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L10
 #. URL: http://smart.who.int/base/authoring-skills.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L15
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L22
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L28
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L41
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L56
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L65
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L73
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L81
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L15
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L22
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L28
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L41
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L56
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L65
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L73
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L81
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:10
 #: input/pagecontent/authoring-skills.md:15
@@ -566,54 +566,54 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L34
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L34
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:34
 msgid "Develop DMN decision-support logic tables"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L35
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L35
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:35
 msgid "Develop DMN scheduling logic tables"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L3
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:3
 msgid "Each authoring skill is modeled as a FHIR Requirements resource conforming to the SGRequirements profile. Each skill states a capability (e.g. \"Can review terminology\") and contains checklist statements that define the criteria for demonstrating that capability."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L88
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L88
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:88
 msgid "Each persona has a defined package of skills. The full set of skills for each persona is available on the persona's Requirements resource page:"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L18
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L18
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:18
 msgid "Engage SMEs, coordinate consultations, manage RASCI"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L43
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L43
 #. URL: http://smart.who.int/base/authoring-skills.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L44
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L45
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L46
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L47
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L48
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L49
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L50
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L51
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L52
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L53
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L96
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L44
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L45
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L46
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L47
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L48
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L49
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L50
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L51
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L52
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L53
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L96
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:43
 #: input/pagecontent/authoring-skills.md:44
@@ -630,121 +630,121 @@ msgstr ""
 msgid "FHIR Modeller"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L100
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L100
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:100
 msgid "IG Configuration, Build, Release, Governance"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L25
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L25
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:25
 msgid "Interpret clinical recommendations with domain expertise"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L90
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L90
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:90
 msgid "Key Domains"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L21
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L21
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:21
 msgid "L1 Review Skills"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L94
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L94
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:94
 msgid "L1 Review, Clinical Interpretation, DAK Validation"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L93
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L93
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:93
 msgid "L1 Review, Stakeholder Management, DAK Validation"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L95
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L95
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:95
 msgid "L2 DAK Authoring (all 9 components), L1 Review"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L27
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L27
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:27
 msgid "L2 DAK Authoring Skills"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L40
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L40
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:40
 msgid "L3 FHIR Authoring Skills"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L96
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L96
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:96
 msgid "L3 FHIR Authoring, Terminology, QA, IG Build"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L78
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L78
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:78
 msgid "Manage cross-IG shared artifacts and governance"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L77
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L77
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:77
 msgid "Manage versioning, tags, and publication workflow"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L59
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L59
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:59
 msgid "Map to WHO Commons, ICD-11, SNOMED CT, LOINC"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L90
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L90
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:90
 msgid "Persona"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L86
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L86
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:86
 msgid "Persona Skill Packages"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L10
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L10
 #. URL: http://smart.who.int/base/authoring-skills.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L15
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L22
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L28
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L41
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L56
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L65
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L73
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L81
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L15
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L22
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L28
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L41
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L56
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L65
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L73
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L81
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:10
 #: input/pagecontent/authoring-skills.md:15
@@ -758,17 +758,17 @@ msgstr ""
 msgid "Personas"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L19
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L19
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:19
 msgid "Plan sprints, maintain backlog, facilitate retrospectives"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L17
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L17
 #. URL: http://smart.who.int/base/authoring-skills.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L19
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L92
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L19
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L92
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:17
 #: input/pagecontent/authoring-skills.md:19
@@ -776,70 +776,70 @@ msgstr ""
 msgid "Programme Manager"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L18
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L18
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:18
 msgid "Programme Manager, Technical Officer"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L92
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L92
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:92
 msgid "Project Management"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L14
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L14
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:14
 msgid "Project Management Skills"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L77
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L77
 #. URL: http://smart.who.int/base/authoring-skills.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L100
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L100
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:77
 #: input/pagecontent/authoring-skills.md:100
 msgid "Publication Manager"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L75
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L75
 #. URL: http://smart.who.int/base/authoring-skills.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L76
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L76
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:75
 #: input/pagecontent/authoring-skills.md:76
 msgid "Publication Manager, FHIR Modeller"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L78
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L78
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:78
 msgid "Publication Manager, Terminologist"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L72
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L72
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:72
 msgid "Publication Skills"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L98
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L98
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:98
 msgid "QA, Checklists, Conformance, Functionality Testing"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L69
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L69
 #. URL: http://smart.who.int/base/authoring-skills.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L70
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L98
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L70
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L98
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:69
 #: input/pagecontent/authoring-skills.md:70
@@ -847,107 +847,107 @@ msgstr ""
 msgid "QC Reviewer"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L67
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L67
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:67
 msgid "QC Reviewer, FHIR Modeller, Publication Manager, Terminologist"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L68
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L68
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:68
 msgid "QC Reviewer, Publication Manager"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L64
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L64
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:64
 msgid "Quality Control Skills"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L108
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L108
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:108
 msgid "Referencing an ActorDefinition from a dependency IG"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L12
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L12
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:12
 msgid "Review and formally approve content at decision gates"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L38
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L38
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:38
 msgid "Review DAK for L1 accuracy and cross-component consistency"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L68
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L68
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:68
 msgid "Review publication checklist across L1-L4"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L58
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L58
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:58
 msgid "Review terminology bindings, code systems, and value sets"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L84
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L84
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:84
 msgid "Review translated content for accuracy"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L24
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L24
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:24
 msgid "Review WHO L1 guidelines for accuracy and completeness"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L67
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L67
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:67
 msgid "Run and interpret IG Publisher QA reports"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L76
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L76
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:76
 msgid "Run IG Publisher build process"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L75
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L75
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:75
 msgid "Set up IG repository and sushi-config"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L10
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L10
 #. URL: http://smart.who.int/base/authoring-skills.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L15
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L22
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L28
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L41
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L56
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L65
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L73
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L81
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L15
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L22
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L28
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L41
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L56
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L65
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L73
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L81
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:10
 #: input/pagecontent/authoring-skills.md:15
@@ -961,56 +961,56 @@ msgstr ""
 msgid "Skill"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L90
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L90
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:90
 msgid "Skill Count"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L7
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:7
 msgid "Skill Inventory"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L5
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:5
 msgid "Skills are organized by domain and assigned to authoring personas to define each persona's skill package."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L93
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L93
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:93
 msgid "Technical Officer"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L24
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L24
 #. URL: http://smart.who.int/base/authoring-skills.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L38
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L38
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:24
 #: input/pagecontent/authoring-skills.md:38
 msgid "Technical Officer, Clinical SME, Business Analyst, QC Reviewer"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L59
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L59
 #. URL: http://smart.who.int/base/authoring-skills.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L97
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L97
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:59
 #: input/pagecontent/authoring-skills.md:97
 msgid "Terminologist"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L60
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L60
 #. URL: http://smart.who.int/base/authoring-skills.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L61
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L62
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L61
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L62
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:60
 #: input/pagecontent/authoring-skills.md:61
@@ -1018,86 +1018,86 @@ msgstr ""
 msgid "Terminologist, FHIR Modeller"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L58
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L58
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:58
 msgid "Terminologist, QC Reviewer"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L97
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L97
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:97
 msgid "Terminology Management, Governance"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L55
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L55
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:55
 msgid "Terminology Skills"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L70
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L70
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:70
 msgid "Test StructureMaps, CQL, and Measures"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L83
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L83
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:83
 msgid "Translate IG content across UN languages"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L80
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L80
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:80
 msgid "Translation Skills"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L101
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L101
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:101
 msgid "Translation, Review"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L83
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L83
 #. URL: http://smart.who.int/base/authoring-skills.html
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L101
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L101
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:83
 #: input/pagecontent/authoring-skills.md:101
 msgid "Translator"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L84
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L84
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:84
 msgid "Translator, QC Reviewer"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L69
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L69
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:69
 msgid "Verify CRMI profile conformance"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L107
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L107
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:107
 msgid "When a swimlane has no matching ActorDefinition, the author must resolve by:"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/authoring-skills.md#L46
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/authoring-skills.md#L46
 #. URL: http://smart.who.int/base/authoring-skills.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/authoring-skills.html
 #: input/pagecontent/authoring-skills.md:46

--- a/input/pagecontent/translations/changes.pot
+++ b/input/pagecontent/translations/changes.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,14 +16,14 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/changes.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/changes.md#L5
 #. URL: http://smart.who.int/base/changes.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/changes.html
 #: input/pagecontent/changes.md:5
 msgid "Initial Release"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/changes.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/changes.md#L3
 #. URL: http://smart.who.int/base/changes.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/changes.html
 #: input/pagecontent/changes.md:3

--- a/input/pagecontent/translations/dak-api.pot
+++ b/input/pagecontent/translations/dak-api.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/dak-api.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/dak-api.md#L3
 #. URL: http://smart.who.int/base/dak-api.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/dak-api.html
 #: input/pagecontent/dak-api.md:3
 msgid "DAK API Documentation Hub"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/dak-api.md#L9
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/dak-api.md#L9
 #. URL: http://smart.who.int/base/dak-api.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/dak-api.html
 #: input/pagecontent/dak-api.md:9
 msgid "Table of Contents"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/dak-api.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/dak-api.md#L5
 #. URL: http://smart.who.int/base/dak-api.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/dak-api.html
 #: input/pagecontent/dak-api.md:5
 msgid "This page provides access to Data Access Kit (DAK) API documentation and schemas."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/dak-api.md#L12
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/dak-api.md#L12
 #. URL: http://smart.who.int/base/dak-api.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/dak-api.html
 #: input/pagecontent/dak-api.md:12

--- a/input/pagecontent/translations/downloads.pot
+++ b/input/pagecontent/translations/downloads.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/downloads.md#L3
 #. URL: http://smart.who.int/base/downloads.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
 #: input/pagecontent/downloads.md:3

--- a/input/pagecontent/translations/index.pot
+++ b/input/pagecontent/translations/index.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,238 +16,238 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L7
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:7
 msgid "A Digital Adaptation Kit (DAK) is the primary artefact of WHO SMART Guidelines. It is a structured, standardised package of clinical and operational content that represents a WHO health intervention in a computable form. Each DAK contains:"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L52
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L52
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:52
 msgid "All Repositories: Preview URLs use the GitHub Pages pattern  for current CI builds."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L30
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L30
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:30
 msgid "Authoring Lifecycle"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L54
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L54
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:54
 msgid "Branch-Based URL Selection"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L12
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L12
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:12
 msgid "Business processes and workflows – step-by-step care pathways"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L13
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L13
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:13
 msgid "Core data elements – the data dictionary for the health domain"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L64
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L64
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:64
 msgid "Cross Version Analysis"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L43
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L43
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:43
 msgid "DAK (Digital Adaptation Kit) URL Handling"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L14
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L14
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:14
 msgid "Decision-support logic – computable clinical decision rules"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L60
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L60
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:60
 msgid "Dependencies"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L56
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L56
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:56
 msgid "Development Branches: Use preview URLs for canonical references and resource identifiers."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L21
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L21
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:21
 msgid "Figure 1 – The nine components of a WHO Digital Adaptation Kit (DAK)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L34
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L34
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:34
 msgid "Figure 2 – DAK Authoring Lifecycle (BPMN 2.0). See Authoring Process for details."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L45
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L45
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:45
 msgid "For repositories that contain a  file in the root directory, this implementation guide provides enhanced URL handling for publication and preview scenarios:"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L15
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L15
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:15
 msgid "Functional and non-functional requirements – system capability requirements"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L10
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L10
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:10
 msgid "Generic personas – representative end-users and actors in the health system"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L68
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L68
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:68
 msgid "Global Profiles"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L9
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L9
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:9
 msgid "Health interventions and recommendations – the clinical guidance from WHO"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L72
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L72
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:72
 msgid "IP Statements"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L49
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L49
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:49
 msgid "Other Repositories: Use the canonical URL specified in  or fall back to GitHub Pages pattern."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L3
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:3
 msgid "Overview"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L51
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L51
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:51
 msgid "Preview URLs"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L16
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L16
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:16
 msgid "Program indicators – aggregate measures and metrics for monitoring and evaluation"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L47
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L47
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:47
 msgid "Publication URLs"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L55
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L55
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:55
 msgid "Release Branches (prefixed with ): Use publication URLs for canonical references and resource identifiers."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L41
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L41
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:41
 msgid "See the SMART IG Starter Kit for more information on building and using WHO SMART Guidelines."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L17
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L17
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:17
 msgid "Test scenarios – structured tests to validate conformance"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L32
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L32
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:32
 msgid "The DAK authoring lifecycle is a five-phase process spanning planning, L2 DAK authoring, L3 FHIR authoring, quality control, and publication. The BPMN 2.0 collaboration diagram below shows the end-to-end process with swimlanes for each authoring persona."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L58
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L58
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:58
 msgid "The DAK configuration is automatically regenerated during CI builds to ensure URLs are appropriate for the current branch context."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L19
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L19
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:19
 msgid "The diagram below illustrates the nine components of a WHO DAK and how they relate to one another:"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L28
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L28
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:28
 msgid "This implementation guide contains base conformance resources for use in all WHO SMART Guidelines implementation guides."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L11
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L11
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:11
 msgid "User scenarios – narrative descriptions of how the guidance is used in practice"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L48
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L48
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:48
 msgid "WHO Repositories: For repositories owned by , the publication URL follows the pattern  where  is the repository name with any  prefix removed."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/index.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/index.md#L5
 #. URL: http://smart.who.int/base/index.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/index.html
 #: input/pagecontent/index.md:5

--- a/input/pagecontent/translations/license.pot
+++ b/input/pagecontent/translations/license.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-20 00:36+0000\n"
+"POT-Creation-Date: 2026-03-23 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,91 +16,91 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=(n==1 ? 0 : n==2 ? 1 : n>=3 && n<=10 ? 2 : n>=11 && n<=99 ? 3 : 4);\n"
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/license.md#L12
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/license.md#L12
 #. URL: http://smart.who.int/base/license.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/license.html
 #: input/pagecontent/license.md:12
 msgid "Adapt: Remix, transform, and build upon the material for any purpose, even commercially."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/license.md#L16
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/license.md#L16
 #. URL: http://smart.who.int/base/license.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/license.html
 #: input/pagecontent/license.md:16
 msgid "Attribution: You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/license.md#L3
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/license.md#L3
 #. URL: http://smart.who.int/base/license.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/license.html
 #: input/pagecontent/license.md:3
 msgid "Creative Commons Attribution 3.0 IGO (CC-BY-3.0-IGO)"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/license.md#L20
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/license.md#L20
 #. URL: http://smart.who.int/base/license.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/license.html
 #: input/pagecontent/license.md:20
 msgid "International Government Organizations (IGOs): This license is specifically designed for works created by International Government Organizations."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/license.md#L22
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/license.md#L22
 #. URL: http://smart.who.int/base/license.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/license.html
 #: input/pagecontent/license.md:22
 msgid "License Text"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/license.md#L18
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/license.md#L18
 #. URL: http://smart.who.int/base/license.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/license.html
 #: input/pagecontent/license.md:18
 msgid "No Additional Restrictions: You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/license.md#L11
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/license.md#L11
 #. URL: http://smart.who.int/base/license.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/license.html
 #: input/pagecontent/license.md:11
 msgid "Share: Copy and redistribute the material in any medium or format."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/license.md#L5
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/license.md#L5
 #. URL: http://smart.who.int/base/license.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/license.html
 #: input/pagecontent/license.md:5
 msgid "Summary"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/license.md#L7
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/license.md#L7
 #. URL: http://smart.who.int/base/license.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/license.html
 #: input/pagecontent/license.md:7
 msgid "This is a human-readable summary of the Creative Commons Attribution 3.0 IGO (CC-BY-3.0-IGO) License. This summary is not a substitute for the full license text."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/license.md#L24
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/license.md#L24
 #. URL: http://smart.who.int/base/license.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/license.html
 #: input/pagecontent/license.md:24
 msgid "This work is licensed under the Creative Commons Attribution 3.0 IGO (CC-BY-3.0-IGO) License."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/license.md#L26
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/license.md#L26
 #. URL: http://smart.who.int/base/license.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/license.html
 #: input/pagecontent/license.md:26
 msgid "To view a copy of this license, visit https://creativecommons.org/licenses/by/3.0/igo/ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA."
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/license.md#L14
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/license.md#L14
 #. URL: http://smart.who.int/base/license.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/license.html
 #: input/pagecontent/license.md:14
 msgid "Under the following conditions:"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/license.md#L9
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/claude/strip-binary-data-08KqE/input/pagecontent/license.md#L9
 #. URL: http://smart.who.int/base/license.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/license.html
 #: input/pagecontent/license.md:9

--- a/input/scripts/strip_library_binaries.py
+++ b/input/scripts/strip_library_binaries.py
@@ -10,8 +10,10 @@ Library resources contain a ``content`` array whose entries carry a
 (application/elm+json, application/elm+xml) are large and not needed in
 the published site.  CQL source (text/cql) is kept.
 
-This script modifies both:
+This script modifies:
   - **JSON files** (Library-*.json): clears ``content[].data`` for ELM entries.
+  - **XML files**  (Library-*.xml):  clears ``<data value="…"/>`` for ELM entries.
+  - **TTL files**  (Library-*.ttl):  clears base64 literals for ELM entries.
   - **HTML files** (Library-*.html): strips the long base64 strings from
     the rendered JSON and XML representations embedded in the page.
 
@@ -28,6 +30,7 @@ import json
 import logging
 import re
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 
@@ -90,6 +93,110 @@ def strip_library_json(output_dir: Path) -> int:
                 json.dumps(resource, indent=2, ensure_ascii=False) + "\n",
                 encoding="utf-8",
             )
+            modified += 1
+            logger.info("Stripped ELM data from %s", fpath.name)
+
+    return modified
+
+
+# ---------------------------------------------------------------------------
+# XML processing
+# ---------------------------------------------------------------------------
+
+_FHIR_NS = "http://hl7.org/fhir"
+_NS = {"f": _FHIR_NS}
+
+
+def strip_library_xml(output_dir: Path) -> int:
+    """Strip ELM base64 data from Library-*.xml files.
+
+    Returns the number of files modified.
+    """
+    modified = 0
+    for fpath in sorted(output_dir.glob("Library-*.xml")):
+        try:
+            tree = ET.parse(fpath)  # noqa: S314
+        except ET.ParseError as exc:
+            logger.warning("Skipping %s: %s", fpath.name, exc)
+            continue
+
+        root = tree.getroot()
+        if root.tag != f"{{{_FHIR_NS}}}Library":
+            continue
+
+        changed = False
+        for content_el in root.findall("f:content", _NS):
+            ct_el = content_el.find("f:contentType", _NS)
+            if ct_el is None:
+                continue
+            ct_value = ct_el.get("value", "")
+            if ct_value not in _ELM_CONTENT_TYPES:
+                continue
+            data_el = content_el.find("f:data", _NS)
+            if data_el is not None and data_el.get("value"):
+                data_el.set("value", "")
+                changed = True
+
+        if changed:
+            # Preserve the XML declaration and namespace prefixes as written
+            # by the IG Publisher.  ElementTree cannot round-trip perfectly,
+            # so fall back to a regex-based approach on the raw text instead.
+            raw = fpath.read_text(encoding="utf-8")
+            new_raw = _strip_elm_data_in_raw_xml(raw)
+            if new_raw != raw:
+                fpath.write_text(new_raw, encoding="utf-8")
+                modified += 1
+                logger.info("Stripped ELM data from %s", fpath.name)
+
+    return modified
+
+
+# Regex for raw FHIR XML: match <contentType value="application/elm+…"/>
+# followed (non-greedy) by <data value="…base64…"/> and clear the value.
+_RAW_XML_ELM_DATA_RE = re.compile(
+    r'(<contentType\s+value="application/elm\+(?:json|xml)"\s*/>'
+    r'.*?'
+    r'<data\s+value=")[A-Za-z0-9+/=]+(")',
+    re.DOTALL,
+)
+
+
+def _strip_elm_data_in_raw_xml(raw: str) -> str:
+    """Replace ELM base64 data values with empty strings in raw FHIR XML."""
+    return _RAW_XML_ELM_DATA_RE.sub(r"\1\2", raw)
+
+
+# ---------------------------------------------------------------------------
+# TTL (Turtle/RDF) processing
+# ---------------------------------------------------------------------------
+
+# In the Turtle serialisation the IG Publisher renders content entries as e.g.:
+#   fhir:contentType [ fhir:v "application/elm+json" ] ;
+#   fhir:data [ fhir:v "eyJ…base64…"^^xsd:base64Binary ]
+_TTL_ELM_DATA_RE = re.compile(
+    r'(fhir:contentType\s+\[\s*fhir:v\s+"application/elm\+(?:json|xml)"\s*\]'
+    r'.*?'
+    r'fhir:data\s+\[\s*fhir:v\s+")[A-Za-z0-9+/=]+(")',
+    re.DOTALL,
+)
+
+
+def strip_library_ttl(output_dir: Path) -> int:
+    """Strip ELM base64 data from Library-*.ttl files.
+
+    Returns the number of files modified.
+    """
+    modified = 0
+    for fpath in sorted(output_dir.glob("Library-*.ttl")):
+        try:
+            raw = fpath.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.warning("Skipping %s: %s", fpath.name, exc)
+            continue
+
+        new_raw = _TTL_ELM_DATA_RE.sub(r"\1\2", raw)
+        if new_raw != raw:
+            fpath.write_text(new_raw, encoding="utf-8")
             modified += 1
             logger.info("Stripped ELM data from %s", fpath.name)
 
@@ -164,10 +271,14 @@ def main() -> None:
 
     logger.info("Stripping ELM binary data from Library resources in %s", output_dir)
     json_count = strip_library_json(output_dir)
+    xml_count = strip_library_xml(output_dir)
+    ttl_count = strip_library_ttl(output_dir)
     html_count = strip_library_html(output_dir)
     logger.info(
-        "Done — %d JSON file(s) and %d HTML file(s) modified",
+        "Done — %d JSON, %d XML, %d TTL, %d HTML file(s) modified",
         json_count,
+        xml_count,
+        ttl_count,
         html_count,
     )
 

--- a/input/scripts/strip_library_binaries.py
+++ b/input/scripts/strip_library_binaries.py
@@ -26,6 +26,7 @@ Defaults:
 Author: SMART Guidelines Team
 """
 
+import html
 import json
 import logging
 import re
@@ -51,21 +52,58 @@ _ELM_CONTENT_TYPES = {
     "application/elm+xml",
 }
 
+_FHIR_NS = "http://hl7.org/fhir"
+_XHTML_NS = "http://www.w3.org/1999/xhtml"
 
-# ---------------------------------------------------------------------------
-# JSON processing
-# ---------------------------------------------------------------------------
 
 def _is_elm(entry: dict) -> bool:
     """Return True if a content entry is an ELM payload."""
     return entry.get("contentType", "") in _ELM_CONTENT_TYPES
 
 
-def strip_library_json(output_dir: Path) -> int:
-    """Strip ELM base64 data from Library-*.json files.
+def _strip_elm_from_dict(resource: dict) -> bool:
+    """Clear ``data`` on ELM content entries in a Library dict.
 
-    Returns the number of files modified.
+    Returns True if anything was changed.
     """
+    contents = resource.get("content")
+    if not isinstance(contents, list):
+        return False
+    changed = False
+    for entry in contents:
+        if _is_elm(entry) and entry.get("data"):
+            entry["data"] = ""
+            changed = True
+    return changed
+
+
+def _strip_elm_from_xml_tree(root: ET.Element) -> bool:
+    """Clear ``data`` on ELM content entries in a parsed FHIR XML tree.
+
+    Returns True if anything was changed.
+    """
+    ns = {"f": _FHIR_NS}
+    changed = False
+    for content_el in root.findall("f:content", ns):
+        ct_el = content_el.find("f:contentType", ns)
+        if ct_el is None:
+            continue
+        if ct_el.get("value", "") not in _ELM_CONTENT_TYPES:
+            continue
+        data_el = content_el.find("f:data", ns)
+        if data_el is not None and data_el.get("value"):
+            data_el.set("value", "")
+            changed = True
+    return changed
+
+
+# ---------------------------------------------------------------------------
+# JSON processing
+# ---------------------------------------------------------------------------
+
+
+def strip_library_json(output_dir: Path) -> int:
+    """Strip ELM base64 data from Library-*.json files."""
     modified = 0
     for fpath in sorted(output_dir.glob("Library-*.json")):
         try:
@@ -78,17 +116,7 @@ def strip_library_json(output_dir: Path) -> int:
         if resource.get("resourceType") != "Library":
             continue
 
-        contents = resource.get("content")
-        if not isinstance(contents, list):
-            continue
-
-        changed = False
-        for entry in contents:
-            if _is_elm(entry) and entry.get("data"):
-                entry["data"] = ""
-                changed = True
-
-        if changed:
+        if _strip_elm_from_dict(resource):
             fpath.write_text(
                 json.dumps(resource, indent=2, ensure_ascii=False) + "\n",
                 encoding="utf-8",
@@ -103,15 +131,13 @@ def strip_library_json(output_dir: Path) -> int:
 # XML processing
 # ---------------------------------------------------------------------------
 
-_FHIR_NS = "http://hl7.org/fhir"
-_NS = {"f": _FHIR_NS}
+# Register namespaces so ElementTree preserves them on write-back.
+ET.register_namespace("", _FHIR_NS)
+ET.register_namespace("xhtml", _XHTML_NS)
 
 
 def strip_library_xml(output_dir: Path) -> int:
-    """Strip ELM base64 data from Library-*.xml files.
-
-    Returns the number of files modified.
-    """
+    """Strip ELM base64 data from Library-*.xml files."""
     modified = 0
     for fpath in sorted(output_dir.glob("Library-*.xml")):
         try:
@@ -124,68 +150,34 @@ def strip_library_xml(output_dir: Path) -> int:
         if root.tag != f"{{{_FHIR_NS}}}Library":
             continue
 
-        changed = False
-        for content_el in root.findall("f:content", _NS):
-            ct_el = content_el.find("f:contentType", _NS)
-            if ct_el is None:
-                continue
-            ct_value = ct_el.get("value", "")
-            if ct_value not in _ELM_CONTENT_TYPES:
-                continue
-            data_el = content_el.find("f:data", _NS)
-            if data_el is not None and data_el.get("value"):
-                data_el.set("value", "")
-                changed = True
-
-        if changed:
-            # Preserve the XML declaration and namespace prefixes as written
-            # by the IG Publisher.  ElementTree cannot round-trip perfectly,
-            # so fall back to a regex-based approach on the raw text instead.
-            raw = fpath.read_text(encoding="utf-8")
-            new_raw = _strip_elm_data_in_raw_xml(raw)
-            if new_raw != raw:
-                fpath.write_text(new_raw, encoding="utf-8")
-                modified += 1
-                logger.info("Stripped ELM data from %s", fpath.name)
+        if _strip_elm_from_xml_tree(root):
+            tree.write(fpath, encoding="unicode", xml_declaration=True)
+            modified += 1
+            logger.info("Stripped ELM data from %s", fpath.name)
 
     return modified
-
-
-# Regex for raw FHIR XML: match <contentType value="application/elm+…"/>
-# followed (non-greedy) by <data value="…base64…"/> and clear the value.
-_RAW_XML_ELM_DATA_RE = re.compile(
-    r'(<contentType\s+value="application/elm\+(?:json|xml)"\s*/>'
-    r'.*?'
-    r'<data\s+value=")[A-Za-z0-9+/=]+(")',
-    re.DOTALL,
-)
-
-
-def _strip_elm_data_in_raw_xml(raw: str) -> str:
-    """Replace ELM base64 data values with empty strings in raw FHIR XML."""
-    return _RAW_XML_ELM_DATA_RE.sub(r"\1\2", raw)
 
 
 # ---------------------------------------------------------------------------
 # TTL (Turtle/RDF) processing
 # ---------------------------------------------------------------------------
 
-# In the Turtle serialisation the IG Publisher renders content entries as e.g.:
+# No Turtle parser in the standard library.  We use a targeted regex that
+# matches the IG Publisher's predictable serialisation of content entries:
+#
 #   fhir:contentType [ fhir:v "application/elm+json" ] ;
 #   fhir:data [ fhir:v "eyJ…base64…"^^xsd:base64Binary ]
 _TTL_ELM_DATA_RE = re.compile(
-    r'(fhir:contentType\s+\[\s*fhir:v\s+"application/elm\+(?:json|xml)"\s*\]'
-    r'.*?'
+    r"(fhir:contentType\s+\[\s*fhir:v\s+"
+    r'"application/elm\+(?:json|xml)"\s*\]'
+    r".*?"
     r'fhir:data\s+\[\s*fhir:v\s+")[A-Za-z0-9+/=]+(")',
     re.DOTALL,
 )
 
 
 def strip_library_ttl(output_dir: Path) -> int:
-    """Strip ELM base64 data from Library-*.ttl files.
-
-    Returns the number of files modified.
-    """
+    """Strip ELM base64 data from Library-*.ttl files."""
     modified = 0
     for fpath in sorted(output_dir.glob("Library-*.ttl")):
         try:
@@ -207,52 +199,75 @@ def strip_library_ttl(output_dir: Path) -> int:
 # HTML processing
 # ---------------------------------------------------------------------------
 
-# In the JSON view the IG Publisher renders:
-#   "contentType" : "application/elm+json",
-#   "data" : "eyJ…very long base64…"
-# We match the contentType line, optional whitespace/lines, then the data line
-# and replace just the base64 value with an empty string.
-_JSON_ELM_DATA_RE = re.compile(
-    r'("contentType"\s*:\s*"application/elm\+(?:json|xml)"'  # contentType line
-    r'.*?'                                                    # anything between
-    r'"data"\s*:\s*)"[A-Za-z0-9+/=]+"',                      # data value
+# The IG Publisher embeds the full resource representation inside
+# <pre class="json"><code>…</code></pre> and
+# <pre class="xml"><code>…</code></pre> blocks.
+# We locate each block, extract and unescape the text content, parse it
+# with the proper parser (json / XML), strip ELM data, and write it back.
+
+_PRE_CODE_RE = re.compile(
+    r'(<pre\s+class="(json|xml|rdf)"\s*>\s*<code[^>]*>)'
+    r"(.*?)"
+    r"(</code>\s*</pre>)",
     re.DOTALL,
 )
 
-# In the XML view the IG Publisher renders:
-#   <contentType value="application/elm+json"/>
-#   <data value="eyJ…very long base64…"/>
-_XML_ELM_DATA_RE = re.compile(
-    r'(&lt;contentType\s+value=(?:&quot;|")application/elm\+(?:json|xml)(?:&quot;|")\s*/&gt;'
-    r'.*?'
-    r'&lt;data\s+value=(?:&quot;|"))[A-Za-z0-9+/=]+((?:&quot;|")\s*/&gt;)',
-    re.DOTALL,
-)
+
+def _replace_html_code_block(match: re.Match) -> str:
+    """Callback for _PRE_CODE_RE: parse the embedded content and strip ELM."""
+    prefix = match.group(1)
+    lang = match.group(2)
+    encoded_body = match.group(3)
+    suffix = match.group(4)
+
+    body = html.unescape(encoded_body)
+
+    if lang == "json":
+        try:
+            resource = json.loads(body)
+        except (json.JSONDecodeError, ValueError):
+            return match.group(0)
+        if resource.get("resourceType") != "Library":
+            return match.group(0)
+        if not _strip_elm_from_dict(resource):
+            return match.group(0)
+        new_body = json.dumps(resource, indent=2, ensure_ascii=False)
+        return prefix + html.escape(new_body, quote=False) + suffix
+
+    if lang == "xml":
+        try:
+            root = ET.fromstring(body)  # noqa: S314
+        except ET.ParseError:
+            return match.group(0)
+        if root.tag != f"{{{_FHIR_NS}}}Library":
+            return match.group(0)
+        if not _strip_elm_from_xml_tree(root):
+            return match.group(0)
+        new_body = ET.tostring(root, encoding="unicode")
+        return prefix + html.escape(new_body, quote=False) + suffix
+
+    if lang == "rdf":
+        new_body = _TTL_ELM_DATA_RE.sub(r"\1\2", body)
+        if new_body == body:
+            return match.group(0)
+        return prefix + html.escape(new_body, quote=False) + suffix
+
+    return match.group(0)
 
 
 def strip_library_html(output_dir: Path) -> int:
-    """Strip ELM base64 data from Library-*.html files.
-
-    Returns the number of files modified.
-    """
+    """Strip ELM base64 data from Library-*.html files."""
     modified = 0
     for fpath in sorted(output_dir.glob("Library-*.html")):
         try:
-            html = fpath.read_text(encoding="utf-8")
+            raw = fpath.read_text(encoding="utf-8")
         except OSError as exc:
             logger.warning("Skipping %s: %s", fpath.name, exc)
             continue
 
-        new_html = html
-
-        # Strip from JSON representation
-        new_html = _JSON_ELM_DATA_RE.sub(r'\1""', new_html)
-
-        # Strip from XML representation
-        new_html = _XML_ELM_DATA_RE.sub(r"\1\2", new_html)
-
-        if new_html != html:
-            fpath.write_text(new_html, encoding="utf-8")
+        new_raw = _PRE_CODE_RE.sub(_replace_html_code_block, raw)
+        if new_raw != raw:
+            fpath.write_text(new_raw, encoding="utf-8")
             modified += 1
             logger.info("Stripped ELM data from %s", fpath.name)
 
@@ -262,6 +277,7 @@ def strip_library_html(output_dir: Path) -> int:
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+
 
 def main() -> None:
     output_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "output")

--- a/input/scripts/strip_library_binaries.py
+++ b/input/scripts/strip_library_binaries.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
 """
-WHO SMART Guidelines — Strip Binary Data from Library Resources
+WHO SMART Guidelines — Strip ELM Binary Data from Library Resources
 
-Temporary postprocessing step that removes base64-encoded binary data
-from FHIR Library resource JSON files produced by the IG Publisher.
+Temporary postprocessing step that removes base64-encoded ELM data from
+FHIR Library resource files produced by the IG Publisher.
 
 Library resources contain a ``content`` array whose entries carry a
-``data`` field with base64-encoded payloads (CQL source, compiled ELM,
-etc.).  These payloads can be very large and are not needed in the
-published output.  This script replaces every ``data`` value with an
-empty string so the structural metadata (contentType, url, …) is
-preserved while the bulk binary payload is removed.
+``data`` field with base64-encoded payloads.  ELM payloads
+(application/elm+json, application/elm+xml) are large and not needed in
+the published site.  CQL source (text/cql) is kept.
+
+This script modifies both:
+  - **JSON files** (Library-*.json): clears ``content[].data`` for ELM entries.
+  - **HTML files** (Library-*.html): strips the long base64 strings from
+    the rendered JSON and XML representations embedded in the page.
 
 Usage:
     python strip_library_binaries.py [output_dir]
@@ -23,7 +26,7 @@ Author: SMART Guidelines Team
 
 import json
 import logging
-import os
+import re
 import sys
 from pathlib import Path
 
@@ -39,20 +42,29 @@ def setup_logging() -> logging.Logger:
 
 logger = setup_logging()
 
+# Content types whose data should be stripped.
+_ELM_CONTENT_TYPES = {
+    "application/elm+json",
+    "application/elm+xml",
+}
 
-def strip_library_binary_data(output_dir: str) -> int:
-    """Strip base64 data from Library JSON files in *output_dir*.
+
+# ---------------------------------------------------------------------------
+# JSON processing
+# ---------------------------------------------------------------------------
+
+def _is_elm(entry: dict) -> bool:
+    """Return True if a content entry is an ELM payload."""
+    return entry.get("contentType", "") in _ELM_CONTENT_TYPES
+
+
+def strip_library_json(output_dir: Path) -> int:
+    """Strip ELM base64 data from Library-*.json files.
 
     Returns the number of files modified.
     """
-    output_path = Path(output_dir)
-    if not output_path.is_dir():
-        logger.error("Output directory does not exist: %s", output_dir)
-        return 0
-
-    modified_count = 0
-
-    for fpath in sorted(output_path.glob("Library-*.json")):
+    modified = 0
+    for fpath in sorted(output_dir.glob("Library-*.json")):
         try:
             raw = fpath.read_text(encoding="utf-8")
             resource = json.loads(raw)
@@ -69,7 +81,7 @@ def strip_library_binary_data(output_dir: str) -> int:
 
         changed = False
         for entry in contents:
-            if "data" in entry and entry["data"]:
+            if _is_elm(entry) and entry.get("data"):
                 entry["data"] = ""
                 changed = True
 
@@ -78,17 +90,86 @@ def strip_library_binary_data(output_dir: str) -> int:
                 json.dumps(resource, indent=2, ensure_ascii=False) + "\n",
                 encoding="utf-8",
             )
-            modified_count += 1
-            logger.info("Stripped binary data from %s", fpath.name)
+            modified += 1
+            logger.info("Stripped ELM data from %s", fpath.name)
 
-    return modified_count
+    return modified
 
+
+# ---------------------------------------------------------------------------
+# HTML processing
+# ---------------------------------------------------------------------------
+
+# In the JSON view the IG Publisher renders:
+#   "contentType" : "application/elm+json",
+#   "data" : "eyJ…very long base64…"
+# We match the contentType line, optional whitespace/lines, then the data line
+# and replace just the base64 value with an empty string.
+_JSON_ELM_DATA_RE = re.compile(
+    r'("contentType"\s*:\s*"application/elm\+(?:json|xml)"'  # contentType line
+    r'.*?'                                                    # anything between
+    r'"data"\s*:\s*)"[A-Za-z0-9+/=]+"',                      # data value
+    re.DOTALL,
+)
+
+# In the XML view the IG Publisher renders:
+#   <contentType value="application/elm+json"/>
+#   <data value="eyJ…very long base64…"/>
+_XML_ELM_DATA_RE = re.compile(
+    r'(&lt;contentType\s+value=(?:&quot;|")application/elm\+(?:json|xml)(?:&quot;|")\s*/&gt;'
+    r'.*?'
+    r'&lt;data\s+value=(?:&quot;|"))[A-Za-z0-9+/=]+((?:&quot;|")\s*/&gt;)',
+    re.DOTALL,
+)
+
+
+def strip_library_html(output_dir: Path) -> int:
+    """Strip ELM base64 data from Library-*.html files.
+
+    Returns the number of files modified.
+    """
+    modified = 0
+    for fpath in sorted(output_dir.glob("Library-*.html")):
+        try:
+            html = fpath.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.warning("Skipping %s: %s", fpath.name, exc)
+            continue
+
+        new_html = html
+
+        # Strip from JSON representation
+        new_html = _JSON_ELM_DATA_RE.sub(r'\1""', new_html)
+
+        # Strip from XML representation
+        new_html = _XML_ELM_DATA_RE.sub(r"\1\2", new_html)
+
+        if new_html != html:
+            fpath.write_text(new_html, encoding="utf-8")
+            modified += 1
+            logger.info("Stripped ELM data from %s", fpath.name)
+
+    return modified
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
 
 def main() -> None:
-    output_dir = sys.argv[1] if len(sys.argv) > 1 else "output"
-    logger.info("Stripping binary data from Library resources in %s", output_dir)
-    count = strip_library_binary_data(output_dir)
-    logger.info("Done — %d Library file(s) modified", count)
+    output_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "output")
+    if not output_dir.is_dir():
+        logger.error("Output directory does not exist: %s", output_dir)
+        sys.exit(1)
+
+    logger.info("Stripping ELM binary data from Library resources in %s", output_dir)
+    json_count = strip_library_json(output_dir)
+    html_count = strip_library_html(output_dir)
+    logger.info(
+        "Done — %d JSON file(s) and %d HTML file(s) modified",
+        json_count,
+        html_count,
+    )
 
 
 if __name__ == "__main__":

--- a/input/scripts/strip_library_binaries.py
+++ b/input/scripts/strip_library_binaries.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+WHO SMART Guidelines — Strip Binary Data from Library Resources
+
+Temporary postprocessing step that removes base64-encoded binary data
+from FHIR Library resource JSON files produced by the IG Publisher.
+
+Library resources contain a ``content`` array whose entries carry a
+``data`` field with base64-encoded payloads (CQL source, compiled ELM,
+etc.).  These payloads can be very large and are not needed in the
+published output.  This script replaces every ``data`` value with an
+empty string so the structural metadata (contentType, url, …) is
+preserved while the bulk binary payload is removed.
+
+Usage:
+    python strip_library_binaries.py [output_dir]
+
+Defaults:
+    output_dir = ./output
+
+Author: SMART Guidelines Team
+"""
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+
+def setup_logging() -> logging.Logger:
+    """Configure logging for the script."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    return logging.getLogger(__name__)
+
+
+logger = setup_logging()
+
+
+def strip_library_binary_data(output_dir: str) -> int:
+    """Strip base64 data from Library JSON files in *output_dir*.
+
+    Returns the number of files modified.
+    """
+    output_path = Path(output_dir)
+    if not output_path.is_dir():
+        logger.error("Output directory does not exist: %s", output_dir)
+        return 0
+
+    modified_count = 0
+
+    for fpath in sorted(output_path.glob("Library-*.json")):
+        try:
+            raw = fpath.read_text(encoding="utf-8")
+            resource = json.loads(raw)
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Skipping %s: %s", fpath.name, exc)
+            continue
+
+        if resource.get("resourceType") != "Library":
+            continue
+
+        contents = resource.get("content")
+        if not isinstance(contents, list):
+            continue
+
+        changed = False
+        for entry in contents:
+            if "data" in entry and entry["data"]:
+                entry["data"] = ""
+                changed = True
+
+        if changed:
+            fpath.write_text(
+                json.dumps(resource, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            modified_count += 1
+            logger.info("Stripped binary data from %s", fpath.name)
+
+    return modified_count
+
+
+def main() -> None:
+    output_dir = sys.argv[1] if len(sys.argv) > 1 else "output"
+    logger.info("Stripping binary data from Library resources in %s", output_dir)
+    count = strip_library_binary_data(output_dir)
+    logger.info("Done — %d Library file(s) modified", count)
+
+
+if __name__ == "__main__":
+    main()

--- a/input/scripts/translation_config.py
+++ b/input/scripts/translation_config.py
@@ -292,9 +292,10 @@ def derive_github_blob_base(repo_root: Optional[Path] = None) -> Optional[str]:
     3. ``None`` when no repository information can be determined.
     """
     github_repo = os.environ.get("GITHUB_REPOSITORY", "")
-    branch = os.environ.get("GITHUB_REF_NAME", "main")
     if github_repo and "/" in github_repo:
-        return f"https://github.com/{github_repo}/blob/{branch}"
+        # Always link to main — source references in .pot files should be
+        # stable and not reflect transient feature/CI branches.
+        return f"https://github.com/{github_repo}/blob/main"
 
     # Fallback: parse dak.json previewUrl
     if repo_root is not None:


### PR DESCRIPTION
## Summary
This PR adds a new postprocessing step to the build workflow that removes base64-encoded ELM (Executable Logic Model) binary data from FHIR Library resource files, reducing artifact size while preserving CQL source code.

## Key Changes
- **New script**: `input/scripts/strip_library_binaries.py` - A comprehensive Python utility that:
  - Strips ELM binary data (`application/elm+json`, `application/elm+xml`) from Library resources
  - Processes multiple formats: JSON, XML, TTL (Turtle/RDF), and HTML files
  - Preserves CQL source code (`text/cql`) which is needed for reference
  - Uses regex-based and DOM-based approaches for robust parsing across formats
  - Includes detailed logging and error handling

- **Workflow integration**: Updated `.github/workflows/ghbuild.yml` to:
  - Add a new build step "DAK Postprocessing - Strip binary data from Library resources"
  - Execute the script after IG Publisher output generation
  - Only runs when DAK processing is enabled

- **Translation files**: Updated POT (Portable Object Template) files with:
  - New build timestamp (2026-03-23 11:35+0000)
  - Updated GitHub source URLs pointing to the feature branch

## Implementation Details
The script handles multiple serialization formats:
- **JSON**: Clears `content[].data` field for ELM entries
- **XML**: Clears `<data value="…"/>` attributes for ELM entries using namespace-aware parsing
- **TTL**: Uses regex to clear base64 literals in RDF triples
- **HTML**: Strips long base64 strings from embedded JSON/XML representations

The implementation is defensive, with proper error handling for malformed files and logging to track which files were modified.

https://claude.ai/code/session_01QjJQAAPe4vSSwoKqvAH8wd