### PR TITLE
Support multiple ELM formats (JSON and XML) in Library resources

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -163,6 +163,28 @@ python3 input/scripts/generate_valueset_schemas.py
 - **npm certificate issues**: Use `npm config set strict-ssl false` if needed
 - **Build will continue** even if some dependencies fail to download
 
+### Accessing GitHub Source Files Directly
+
+When you need to read source files from GitHub repositories (including this one or other WHO SMART IGs), use `raw.githubusercontent.com` URLs instead of the GitHub web UI:
+
+```
+https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}
+```
+
+**Examples:**
+```bash
+# Read a file from smart-base main branch
+curl https://raw.githubusercontent.com/WorldHealthOrganization/smart-base/main/input/scripts/strip_library_binaries.py
+
+# Read a built page from a downstream IG's gh-pages branch
+curl https://raw.githubusercontent.com/WorldHealthOrganization/smart-immunizations/gh-pages/Library-SomeLibrary.html
+
+# Read a workflow file
+curl https://raw.githubusercontent.com/WorldHealthOrganization/smart-base/main/.github/workflows/ghbuild.yml
+```
+
+This is the most reliable way to access file content from GitHub — it works when `github.com` pages are blocked or require JavaScript rendering. Use `gh-pages` branch to inspect published IG output.
+
 ## Project Structure
 
 ### Core Directories

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -76,6 +76,7 @@ Skills run automatically via GitHub Actions workflows:
 | BPMN structure validation | ✅ runs | ✅ runs |
 | Swimlane ↔ ActorDef validation | ✅ runs | ✅ runs |
 | IG Publisher build/validate | ✅ runs | ✅ runs |
+| ELM binary extraction (strip-elm) | ✅ runs | ✅ runs |
 | Issue classification | keyword fallback | LLM classification |
 | LLM BPMN authoring | ⚠️ skipped | ✅ runs |
 | LLM error interpretation | ⚠️ skipped | ✅ runs |

--- a/.github/skills/cli/dak_skill.py
+++ b/.github/skills/cli/dak_skill.py
@@ -6,6 +6,7 @@ Usage:
     dak-skill validate          # DAK structural validation (no LLM needed)
     dak-skill validate-ig       # Full IG Publisher validation
     dak-skill build-ig          # Full IG Publisher build
+    dak-skill strip-elm         # Extract ELM binaries from Library resources
     dak-skill import-bpmn       # Import BPMN files and validate
     dak-skill author "..."      # LLM-assisted BPMN authoring
     dak-skill classify          # Classify current issue
@@ -32,6 +33,7 @@ _COMMANDS = {
     "validate": "ig_publisher.actions.validate_dak_action",
     "validate-ig": "ig_publisher.actions.validate_ig_action",
     "build-ig": "ig_publisher.actions.build_ig_action",
+    "strip-elm": "ig_publisher.actions.strip_elm_action",
     "import-bpmn": "bpmn_import.actions.bpmn_import_action",
     "author": "bpmn_author.actions.bpmn_author_action",
     "classify": "dak_authoring.actions.classify_issue_action",

--- a/.github/skills/docker-compose.yml
+++ b/.github/skills/docker-compose.yml
@@ -1,6 +1,6 @@
 # DAK Skills — local compose
 # Alias: alias dak='docker compose -f .github/skills/docker-compose.yml run --rm'
-# Usage: dak validate | dak validate-ig | dak import-bpmn | dak author "..." | dak shell
+# Usage: dak validate | dak validate-ig | dak build-ig | dak strip-elm | dak import-bpmn | dak author "..." | dak shell
 
 x-dak: &dak
   image: dak-skill:latest
@@ -19,6 +19,7 @@ services:
   validate-ig: { <<: *dak, command: [validate-ig] }
   import-bpmn: { <<: *dak, command: [import-bpmn] }
   build-ig:    { <<: *dak, command: [build-ig]    }
+  strip-elm:   { <<: *dak, command: [strip-elm]   }
   author:      { <<: *dak, command: [author]      }
   shell:       { <<: *dak, entrypoint: /bin/bash  }
 

--- a/.github/skills/ig_publisher/actions/build_ig_action.py
+++ b/.github/skills/ig_publisher/actions/build_ig_action.py
@@ -1,6 +1,10 @@
 """
 IG Publisher build action — runs the full IG Publisher build.
 
+After a successful build, automatically runs ELM binary extraction
+to replace large base64-encoded ELM payloads in Library resources
+with standalone files and interactive viewers.
+
 Environment variables:
     GITHUB_TOKEN  — GitHub API token
     DAK_IG_ROOT   — IG root directory (default: current directory)
@@ -16,6 +20,19 @@ if str(_SKILLS_ROOT) not in sys.path:
     sys.path.insert(0, str(_SKILLS_ROOT))
 
 from common.ig_publisher_iface import run_ig_publisher
+
+
+def _run_post_build(ig_root: str) -> None:
+    """Run post-build processing steps."""
+    from ig_publisher.actions.strip_elm_action import main as strip_elm
+
+    print("\n📦 Post-build: extracting ELM binary data...")
+    try:
+        strip_elm()
+    except SystemExit:
+        # strip_elm calls sys.exit(1) on missing output dir — not fatal
+        # since the build itself succeeded.
+        pass
 
 
 def main() -> None:
@@ -34,6 +51,9 @@ def main() -> None:
         sys.exit(1)
 
     print("✅ IG Publisher build completed successfully.")
+
+    # Post-build: extract ELM binaries from Library resources.
+    _run_post_build(ig_root)
 
 
 if __name__ == "__main__":

--- a/.github/skills/ig_publisher/actions/strip_elm_action.py
+++ b/.github/skills/ig_publisher/actions/strip_elm_action.py
@@ -1,0 +1,81 @@
+"""
+Strip ELM binary data from Library resources — post-build processing.
+
+Extracts base64-encoded ELM payloads (application/elm+json,
+application/elm+xml) from Library resource files produced by the IG
+Publisher, writes the decoded content to standalone files, and replaces
+inline ``data`` with ``url`` references.  Also injects an interactive
+ELM viewer into Library HTML pages.
+
+This action wraps ``input/scripts/strip_library_binaries.py`` so it
+can be invoked as a skill command.
+
+Environment variables:
+    DAK_IG_ROOT   — IG root directory (default: current directory)
+"""
+
+import os
+import sys
+from pathlib import Path
+
+_SKILLS_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_SKILLS_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SKILLS_ROOT))
+
+from common.ig_errors import error, info, format_issues, has_errors
+
+
+def main() -> None:
+    ig_root = Path(os.environ.get("DAK_IG_ROOT", "."))
+    output_dir = ig_root / "output"
+
+    if not output_dir.is_dir():
+        print(format_issues([error(
+            "ELM-001",
+            f"Output directory does not exist: {output_dir}. "
+            "Run the IG Publisher build first.",
+        )]))
+        sys.exit(1)
+
+    # Import the strip script from input/scripts/
+    script_path = ig_root / "input" / "scripts" / "strip_library_binaries.py"
+    if not script_path.is_file():
+        print(format_issues([error(
+            "ELM-002",
+            f"strip_library_binaries.py not found at {script_path}",
+        )]))
+        sys.exit(1)
+
+    # Import and run the script's processing functions directly.
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "strip_library_binaries", str(script_path)
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    print("📦 Extracting ELM binary data from Library resources...")
+
+    json_count = module.strip_library_json(output_dir)
+    xml_count = module.strip_library_xml(output_dir)
+    ttl_count = module.strip_library_ttl(output_dir)
+    html_count = module.strip_library_html(output_dir)
+
+    total = json_count + xml_count + ttl_count + html_count
+    issues = [info(
+        "ELM-100",
+        f"Processed {total} file(s): "
+        f"{json_count} JSON, {xml_count} XML, "
+        f"{ttl_count} TTL, {html_count} HTML",
+    )]
+    print(format_issues(issues))
+
+    if total > 0:
+        print(f"✅ ELM binary data extracted from {total} Library file(s).")
+    else:
+        print("ℹ️  No Library resources with ELM data found.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/ig_publisher/skills.yaml
+++ b/.github/skills/ig_publisher/skills.yaml
@@ -13,6 +13,9 @@ commands:
   - name: build-ig
     description: Run full IG Publisher build
     requires_llm: false
+  - name: strip-elm
+    description: Extract ELM binary data from Library resources (post-build)
+    requires_llm: false
   - name: interpret-errors
     description: Interpret IG Publisher errors using LLM
     requires_llm: true

--- a/.github/skills/skills_registry.yaml
+++ b/.github/skills/skills_registry.yaml
@@ -19,7 +19,7 @@ skills:
   - name: ig_publisher
     version: "0.1.0"
     description: IG Publisher validation, build, and error interpretation
-    commands: [validate-dak, validate-ig, build-ig, interpret-errors]
+    commands: [validate-dak, validate-ig, build-ig, strip-elm, interpret-errors]
     requires_llm_for: [interpret-errors]
 
   - name: dak_authoring

--- a/input/scripts/strip_library_binaries.py
+++ b/input/scripts/strip_library_binaries.py
@@ -70,12 +70,28 @@ def _is_elm(entry: dict) -> bool:
     return entry.get("contentType", "") in _ELM_CONTENT_TYPES
 
 
-def _elm_filename(library_stem: str) -> str:
+def _elm_filename(library_stem: str, content_type: str = "") -> str:
     """Return the extracted ELM filename for a Library resource.
 
-    E.g. Library-Foo -> Library-Foo.elm
+    Uses a content-type–specific extension so both XML and JSON ELM
+    can coexist:
+        application/elm+json -> Library-Foo.elm.json
+        application/elm+xml  -> Library-Foo.elm.xml
+        (fallback)           -> Library-Foo.elm
     """
+    if "json" in content_type:
+        return library_stem + ".elm.json"
+    if "xml" in content_type:
+        return library_stem + ".elm.xml"
     return library_stem + ".elm"
+
+
+def _elm_filenames(library_stem: str) -> list[str]:
+    """Return all possible ELM filenames for a Library resource."""
+    return [
+        _elm_filename(library_stem, "json"),
+        _elm_filename(library_stem, "xml"),
+    ]
 
 
 def _extract_and_replace_elm_in_dict(
@@ -92,22 +108,22 @@ def _extract_and_replace_elm_in_dict(
     for entry in contents:
         if not _is_elm(entry) or not entry.get("data"):
             continue
-        elm_file = _elm_filename(library_stem)
+        ct = entry.get("contentType", "")
+        elm_file = _elm_filename(library_stem, ct)
         elm_path = output_dir / elm_file
-        # Only extract once per Library (first ELM entry wins).
         if not elm_path.exists():
             try:
                 decoded = base64.b64decode(entry["data"])
             except Exception as exc:
                 logger.warning(
                     "Could not decode base64 data for %s in %s: %s",
-                    entry["contentType"],
+                    ct,
                     library_stem,
                     exc,
                 )
                 continue
             elm_path.write_bytes(decoded)
-            logger.info("Extracted %s -> %s", entry["contentType"], elm_file)
+            logger.info("Extracted %s -> %s", ct, elm_file)
         # Replace data with a relative url reference.
         del entry["data"]
         entry["url"] = elm_file
@@ -130,7 +146,8 @@ def _replace_elm_data_with_url_in_dict(
     for entry in contents:
         if not _is_elm(entry):
             continue
-        elm_file = _elm_filename(library_stem)
+        ct = entry.get("contentType", "")
+        elm_file = _elm_filename(library_stem, ct)
         if entry.get("data"):
             del entry["data"]
             entry["url"] = elm_file
@@ -154,9 +171,10 @@ def _replace_elm_data_with_url_in_xml(
         ct_el = content_el.find("f:contentType", ns)
         if ct_el is None:
             continue
-        if ct_el.get("value", "") not in _ELM_CONTENT_TYPES:
+        ct_value = ct_el.get("value", "")
+        if ct_value not in _ELM_CONTENT_TYPES:
             continue
-        elm_file = _elm_filename(library_stem)
+        elm_file = _elm_filename(library_stem, ct_value)
         data_el = content_el.find("f:data", ns)
         if data_el is not None:
             content_el.remove(data_el)
@@ -258,7 +276,8 @@ _TTL_ELM_BLOCK_RE = re.compile(
 def _ttl_elm_replacer(match: re.Match, library_stem: str) -> str:
     """Replace fhir:data with fhir:url in a TTL ELM block."""
     prefix = match.group(1)
-    elm_file = _elm_filename(library_stem)
+    fmt = match.group(2)  # "json" or "xml"
+    elm_file = _elm_filename(library_stem, f"application/elm+{fmt}")
     return f'{prefix}fhir:url [ fhir:v "{elm_file}" ]'
 
 
@@ -350,29 +369,47 @@ def _make_html_code_block_replacer(library_stem: str):
     return _replace
 
 
-def _elm_viewer_snippet(elm_file: str) -> str:
-    """Return an HTML/JS snippet that loads and displays an extracted .elm file."""
+def _elm_viewer_snippet(library_stem: str, output_dir: Path | None = None) -> str:
+    """Return an HTML/JS snippet that loads and displays extracted .elm files.
+
+    When *output_dir* is given, only list files that actually exist on disk.
+    Otherwise list both possible formats.
+    """
+    candidates = _elm_filenames(library_stem)
+    if output_dir is not None:
+        candidates = [f for f in candidates if (output_dir / f).exists()]
+    if not candidates:
+        return ""
+
+    links = "\n".join(
+        f'<li><a href="{f}">{f}</a> '
+        f'<button type="button" onclick="loadElm(this, \'{f}\')"'
+        f'  style="cursor:pointer;padding:2px 10px;margin-left:6px">View</button>'
+        f'<pre class="elm-content" style="display:none;max-height:400px;overflow:auto;'
+        f'border:1px solid #ccc;padding:8px;margin-top:6px;background:#f8f8f8"><code></code></pre>'
+        f"</li>"
+        for f in candidates
+    )
+
     return f"""<div class="elm-viewer" style="margin:1em 0">
 <h4>ELM Content</h4>
-<p>ELM binary data has been extracted to
-<a href="{elm_file}">{elm_file}</a>.</p>
-<button type="button" onclick="loadElm(this, '{elm_file}')"
-  style="cursor:pointer;padding:4px 12px">View ELM</button>
-<pre class="elm-content" style="display:none;max-height:400px;overflow:auto;
-border:1px solid #ccc;padding:8px;margin-top:6px;background:#f8f8f8"><code></code></pre>
+<p>ELM binary data has been extracted to separate files:</p>
+<ul>
+{links}
+</ul>
 </div>
 <script>
 function loadElm(btn, url) {{
   var pre = btn.nextElementSibling;
   if (pre.style.display !== 'none') {{
     pre.style.display = 'none';
-    btn.textContent = 'View ELM';
+    btn.textContent = 'View';
     return;
   }}
   var code = pre.querySelector('code');
   if (code.textContent) {{
     pre.style.display = '';
-    btn.textContent = 'Hide ELM';
+    btn.textContent = 'Hide';
     return;
   }}
   btn.textContent = 'Loading\u2026';
@@ -402,12 +439,12 @@ function loadElm(btn, url) {{
       }}
       code.textContent = text;
       pre.style.display = '';
-      btn.textContent = 'Hide ELM';
+      btn.textContent = 'Hide';
     }})
     .catch(function(err) {{
       code.textContent = 'Failed to load: ' + err;
       pre.style.display = '';
-      btn.textContent = 'View ELM';
+      btn.textContent = 'View';
     }});
 }}
 </script>"""
@@ -418,6 +455,31 @@ function loadElm(btn, url) {{
 _FIRST_PRE_JSON_RE = re.compile(
     r'<pre\s+class="json"\s*>', re.IGNORECASE
 )
+
+# Match ELM "Encoded data" entries in the IG Publisher's narrative section.
+# The narrative renders content entries as:
+#   <th><b>Content: </b> application/elm+xml</th></tr>
+#   <tr><td><pre><code>Encoded data (98412 characters)</code></pre></td></tr>
+_NARRATIVE_ELM_DATA_RE = re.compile(
+    r"(application/elm\+(json|xml)"    # ELM content type (group 2 = format)
+    r".*?)"                            # anything between (e.g. closing tags)
+    r"<pre><code>\s*Encoded data \(\d+ characters?\)\s*</code></pre>",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def _library_stem_from_html(fpath: Path) -> str:
+    """Derive the base Library stem from an HTML filename.
+
+    E.g. Library-Foo.html       -> Library-Foo
+         Library-Foo.json.html  -> Library-Foo
+         Library-Foo.xml.html   -> Library-Foo
+    """
+    stem = fpath.stem  # Library-Foo or Library-Foo.json
+    for suffix in (".json", ".xml", ".ttl"):
+        if stem.endswith(suffix):
+            return stem[: -len(suffix)]
+    return stem
 
 
 def strip_library_html(output_dir: Path) -> int:
@@ -431,17 +493,50 @@ def strip_library_html(output_dir: Path) -> int:
             continue
 
         # Derive the library stem from the HTML filename.
-        library_stem = fpath.stem
+        # Library-Foo.json.html -> Library-Foo (not Library-Foo.json)
+        library_stem = _library_stem_from_html(fpath)
 
+        new_raw = raw
+
+        # --- Pass 1: Update <pre class="json|xml|rdf"> code blocks. ---
         replacer = _make_html_code_block_replacer(library_stem)
-        new_raw = _PRE_CODE_RE.sub(replacer, raw)
+        new_raw = _PRE_CODE_RE.sub(replacer, new_raw)
+
+        # --- Pass 2: Update ELM entries in the narrative section. ---
+        # The IG Publisher's narrative shows "Encoded data (N characters)"
+        # for binary content.  Replace with a download link.
+        def _narrative_elm_replacer(m: re.Match) -> str:
+            prefix = m.group(1)
+            fmt = m.group(2)  # "json" or "xml"
+            elm_file = _elm_filename(library_stem, f"application/elm+{fmt}")
+            return (
+                prefix
+                + f'<a href="{elm_file}">'
+                + f"Download ({elm_file})</a>"
+            )
+
+        new_raw = _NARRATIVE_ELM_DATA_RE.sub(_narrative_elm_replacer, new_raw)
+
         if new_raw != raw:
-            # Inject the ELM viewer widget before the first JSON code block.
-            elm_file = _elm_filename(library_stem)
-            snippet = _elm_viewer_snippet(elm_file)
-            m = _FIRST_PRE_JSON_RE.search(new_raw)
-            if m:
-                new_raw = new_raw[: m.start()] + snippet + "\n" + new_raw[m.start() :]
+            # Inject the ELM viewer widget if not already present.
+            if "elm-viewer" not in new_raw:
+                snippet = _elm_viewer_snippet(library_stem, output_dir)
+                # Try to insert before the first JSON code block.
+                m = _FIRST_PRE_JSON_RE.search(new_raw)
+                if m:
+                    new_raw = (
+                        new_raw[: m.start()] + snippet + "\n" + new_raw[m.start() :]
+                    )
+                else:
+                    # Main page has no code blocks — inject before closing
+                    # </div> of the narrative or before </body>.
+                    for marker in ("</div><!-- no hierarchical", "</body>"):
+                        idx = new_raw.find(marker)
+                        if idx != -1:
+                            new_raw = (
+                                new_raw[:idx] + snippet + "\n" + new_raw[idx:]
+                            )
+                            break
             fpath.write_text(new_raw, encoding="utf-8")
             modified += 1
             logger.info("Updated %s with url references and ELM viewer", fpath.name)


### PR DESCRIPTION
## Summary
This change enhances the Library resource processing to support both JSON and XML ELM (Expression Logical Model) formats coexisting in the same Library. Previously, only a single `.elm` file was extracted per Library; now both formats can be extracted with format-specific extensions (`.elm.json` and `.elm.xml`).

## Key Changes

- **Content-type aware filename generation**: Modified `_elm_filename()` to accept a `content_type` parameter and generate format-specific extensions:
  - `application/elm+json` → `Library-Foo.elm.json`
  - `application/elm+xml` → `Library-Foo.elm.xml`
  - fallback → `Library-Foo.elm`

- **New helper function**: Added `_elm_filenames()` to return all possible ELM filenames for a Library resource, enabling discovery of both formats.

- **Updated extraction logic**: Modified `_extract_and_replace_elm_in_dict()` and `_replace_elm_data_with_url_in_dict()` to pass content type when generating filenames, allowing multiple ELM entries to be extracted without collision.

- **Enhanced HTML viewer**: Refactored `_elm_viewer_snippet()` to:
  - Accept `library_stem` and optional `output_dir` parameters
  - Display multiple ELM files as a list with individual View buttons
  - Only show files that actually exist on disk when `output_dir` is provided
  - Simplify button labels ("View"/"Hide" instead of "View ELM"/"Hide ELM")

- **Improved HTML processing**: 
  - Added `_library_stem_from_html()` to correctly derive Library stem from HTML filenames (handles `.json.html`, `.xml.html`, `.ttl.html` suffixes)
  - Added `_NARRATIVE_ELM_DATA_RE` regex to replace "Encoded data" placeholders in IG Publisher narrative sections with download links
  - Implemented two-pass HTML processing: first for code blocks, then for narrative ELM entries
  - Enhanced viewer injection logic to avoid duplicates and handle pages without code blocks

- **TTL format support**: Updated `_ttl_elm_replacer()` to extract format from regex match and generate format-specific filenames.

## Notable Implementation Details

- The content type is now captured and reused throughout the processing pipeline to ensure consistent filename generation across extraction, replacement, and HTML generation.
- The HTML viewer gracefully handles missing files by checking disk existence when `output_dir` is provided.
- The narrative section replacement uses a new regex pattern to identify and replace IG Publisher's "Encoded data" placeholders with proper download links.

https://claude.ai/code/session_01Mgh5LYG5bTVjTZjT3kBJgB