### PR TITLE
Fix hardcoded release links in downstream IG builds

### DIFF
--- a/.github/workflows/ghbuild.yml
+++ b/.github/workflows/ghbuild.yml
@@ -867,6 +867,31 @@ jobs:
             echo "⚠️ inject_build_banner.py not available, skipping"
           fi
 
+      # ── Fix release links for downstream repos ─────────────────────
+      # The downloads.md template contains hardcoded release links
+      # pointing to WorldHealthOrganization/smart-base.  For downstream
+      # IGs that reuse this workflow, replace those links with the
+      # actual repository URL.
+      - name: Fix release links in output pages
+        if: ${{ !cancelled() }}
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ ! -f "input/scripts/fix_release_links.py" ]; then
+            echo "fix_release_links.py not found locally, downloading from smart-base repository..."
+            mkdir -p input/scripts
+            curl -L -f -o "input/scripts/fix_release_links.py" \
+              "${SCRIPTS_BASE_URL}/input/scripts/fix_release_links.py" \
+              2>/dev/null || echo "Failed to download fix_release_links.py"
+          fi
+          if [ -f "input/scripts/fix_release_links.py" ]; then
+            python3 input/scripts/fix_release_links.py \
+              || echo "⚠️ fix_release_links.py exited with error (non-blocking)"
+            echo "✅ Release link fix step complete"
+          else
+            echo "⚠️ fix_release_links.py not available, skipping"
+          fi
+
       # ── Upload large package files as GitHub Release assets ────────
       # Instead of deploying package.db, package.tgz, package.r4.tgz,
       # package.r4b.tgz, and ai.zip to gh-pages (where they bloat the

--- a/input/scripts/fix_release_links.py
+++ b/input/scripts/fix_release_links.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Fix hardcoded GitHub release links in IG Publisher HTML output.
+
+The downloads.md template contains hardcoded release links pointing to
+WorldHealthOrganization/smart-base.  When downstream IGs build using the
+shared ghbuild.yml workflow, these links need to point to the actual
+repository instead.
+
+This postprocessing script scans output/*.html and replaces any
+hardcoded smart-base release URLs with the correct repository URL
+derived from the GITHUB_REPOSITORY environment variable.
+
+Environment variables
+---------------------
+GITHUB_REPOSITORY   ``owner/repo`` — set automatically by GitHub Actions.
+
+Usage:
+    python3 fix_release_links.py [output_dir]
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+# The hardcoded base URL pattern to replace (owner/repo part only)
+_DEFAULT_REPO = "WorldHealthOrganization/smart-base"
+
+
+def fix_release_links(output_dir: Path, actual_repo: str) -> int:
+    """Replace hardcoded smart-base release URLs with the actual repo.
+
+    Returns the number of files modified.
+    """
+    if actual_repo == _DEFAULT_REPO:
+        print(f"ℹ️  Building {_DEFAULT_REPO} itself — no link replacement needed.")
+        return 0
+
+    if not output_dir.is_dir():
+        print(f"⚠️  Output directory not found: {output_dir}")
+        return 0
+
+    # Pattern matches GitHub URLs containing the hardcoded repo
+    pattern = re.compile(
+        re.escape(f"https://github.com/{_DEFAULT_REPO}")
+    )
+    replacement = f"https://github.com/{actual_repo}"
+
+    html_files = sorted(output_dir.rglob("*.html"))
+    modified = 0
+
+    for path in html_files:
+        try:
+            content = path.read_text(encoding="utf-8", errors="replace")
+            new_content = pattern.sub(replacement, content)
+            if new_content != content:
+                path.write_text(new_content, encoding="utf-8")
+                modified += 1
+        except Exception as exc:
+            print(f"⚠️  Could not process {path}: {exc}", file=sys.stderr)
+
+    return modified
+
+
+def main() -> int:
+    output_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output")
+    repo = os.environ.get("GITHUB_REPOSITORY", "").strip()
+
+    if not repo:
+        print("ℹ️  GITHUB_REPOSITORY not set — skipping release link replacement.")
+        return 0
+
+    modified = fix_release_links(output_dir, repo)
+    print(f"✅ Release links: replaced smart-base URLs in {modified} file(s) "
+          f"with {repo}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Add a postprocessing script to replace hardcoded GitHub release links in IG Publisher HTML output. This enables downstream IGs that reuse the shared `ghbuild.yml` workflow to have release links pointing to their own repositories instead of the smart-base repository.

## Changes
- **New script**: `input/scripts/fix_release_links.py`
  - Scans output HTML files for hardcoded `WorldHealthOrganization/smart-base` release URLs
  - Replaces them with the actual repository URL from the `GITHUB_REPOSITORY` environment variable
  - Gracefully handles cases where the script is building smart-base itself (no replacement needed)
  - Includes comprehensive documentation and error handling

- **Updated workflow**: `.github/workflows/ghbuild.yml`
  - Added new "Fix release links in output pages" step after the banner injection step
  - Downloads the script from smart-base if not available locally (for downstream repos)
  - Passes `GITHUB_REPOSITORY` context to the script
  - Non-blocking step that gracefully handles missing script or execution errors

## Implementation Details
- The script uses regex pattern matching to find and replace GitHub URLs
- Processes all HTML files recursively in the output directory
- Returns count of modified files for visibility in workflow logs
- Skips processing if `GITHUB_REPOSITORY` is not set or if building smart-base itself
- Uses emoji indicators in output for better workflow log readability

https://claude.ai/code/session_01Vp8wJQZJbzagNMda9hmgUP