### PR TITLE
Fix PermissionError in strip_library_content.py

### DIFF
--- a/input/scripts/strip_library_content.py
+++ b/input/scripts/strip_library_content.py
@@ -62,10 +62,19 @@ logger = setup_logging()
 
 
 def _ensure_writable(path: str) -> None:
-    """Make *path* writable by the owner if it is not already."""
-    st = os.stat(path)
-    if not st.st_mode & stat.S_IWUSR:
-        os.chmod(path, st.st_mode | stat.S_IWUSR)
+    """Make *path* writable if it is not already.
+
+    Uses ``os.access`` to check effective write permission for the
+    current user and adds user/group/other write bits as needed so that
+    the file can be overwritten regardless of ownership.
+    """
+    if os.access(path, os.W_OK):
+        return
+    try:
+        st = os.stat(path)
+        os.chmod(path, st.st_mode | stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+    except OSError as exc:
+        logger.warning("Could not make %s writable: %s", path, exc)
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix `PermissionError: [Errno 13]` when `strip_library_content.py` runs as a user who does not own the Library JSON/XML files (e.g. in CI)
- `_ensure_writable()` now uses `os.access(path, os.W_OK)` to check effective write permission instead of only checking the owner write bit (`S_IWUSR`)
- Adds user/group/other write bits when needed, with error handling for cases where `chmod` itself is denied

## Test plan

- [ ] Run `strip_library_content.py` against an output directory with read-only Library files owned by a different user — should no longer raise `PermissionError`
- [ ] Run against normal (writable) files — behavior unchanged
- [ ] Verify CI pipeline in smart-immunizations passes the "Replacing inline CQL/ELM data" step

https://claude.ai/code/session_01KwBoxpuPXy93f19y7NrfK3