### PR TITLE
Move IG Publisher zip archives to GitHub Releases

### DIFF
--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -15,5 +15,16 @@ Available assets per release:
 | `package.r4b.tgz` | FHIR NPM package (R4B specific) |
 | `package.db` | FHIR package database (SQLite) |
 | `ai.zip` | AI-ready package archive |
+| `definitions.json.zip` | FHIR definitions (JSON) |
+| `definitions.xml.zip` | FHIR definitions (XML) |
+| `definitions.ttl.zip` | FHIR definitions (Turtle) |
+| `examples.json.zip` | Examples (JSON) |
+| `examples.xml.zip` | Examples (XML) |
+| `examples.ttl.zip` | Examples (Turtle) |
+| `expansions.json.zip` | ValueSet expansions (JSON) |
+| `expansions.xml.zip` | ValueSet expansions (XML) |
+| `csvs.zip` | CSV exports |
+| `excels.zip` | Excel exports |
+| `schematrons.zip` | Schematron validation rules |
 
 [Browse all releases](https://github.com/WorldHealthOrganization/smart-base/releases)

--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -15,6 +15,7 @@ Available assets per release:
 | `package.r4b.tgz` | FHIR NPM package (R4B specific) |
 | `package.db` | FHIR package database (SQLite) |
 | `ai.zip` | AI-ready package archive |
+| `package-combined.tgz` | Combined FHIR NPM package |
 | `definitions.json.zip` | FHIR definitions (JSON) |
 | `definitions.xml.zip` | FHIR definitions (XML) |
 | `definitions.ttl.zip` | FHIR definitions (Turtle) |
@@ -26,5 +27,6 @@ Available assets per release:
 | `csvs.zip` | CSV exports |
 | `excels.zip` | Excel exports |
 | `schematrons.zip` | Schematron validation rules |
+| `spreadsheets.zip` | Individual resource spreadsheets (.xlsx) |
 
 [Browse all releases](https://github.com/WorldHealthOrganization/smart-base/releases)

--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -16,6 +16,7 @@ Available assets per release:
 | `package.db` | FHIR package database (SQLite) |
 | `ai.zip` | AI-ready package archive |
 | `package-combined.tgz` | Combined FHIR NPM package |
+| `validator.pack` | FHIR Validator package |
 | `definitions.json.zip` | FHIR definitions (JSON) |
 | `definitions.xml.zip` | FHIR definitions (XML) |
 | `definitions.ttl.zip` | FHIR definitions (Turtle) |

--- a/input/pagecontent/translations/downloads.pot
+++ b/input/pagecontent/translations/downloads.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WHO SMART Guidelines\n"
-"POT-Creation-Date: 2026-03-23 17:33+0000\n"
+"POT-Creation-Date: 2026-03-24 11:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,11 +30,25 @@ msgstr ""
 msgid "Available assets per release:"
 msgstr ""
 
-#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L19
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L32
 #. URL: http://smart.who.int/base/downloads.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
-#: input/pagecontent/downloads.md:19
+#: input/pagecontent/downloads.md:32
 msgid "Browse all releases"
+msgstr ""
+
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L18
+#. URL: http://smart.who.int/base/downloads.html
+#. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
+#: input/pagecontent/downloads.md:18
+msgid "Combined FHIR NPM package"
+msgstr ""
+
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L27
+#. URL: http://smart.who.int/base/downloads.html
+#. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
+#: input/pagecontent/downloads.md:27
+msgid "CSV exports"
 msgstr ""
 
 #. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L11
@@ -49,6 +63,55 @@ msgstr ""
 #. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
 #: input/pagecontent/downloads.md:3
 msgid "Downloads"
+msgstr ""
+
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L22
+#. URL: http://smart.who.int/base/downloads.html
+#. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
+#: input/pagecontent/downloads.md:22
+msgid "Examples (JSON)"
+msgstr ""
+
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L24
+#. URL: http://smart.who.int/base/downloads.html
+#. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
+#: input/pagecontent/downloads.md:24
+msgid "Examples (Turtle)"
+msgstr ""
+
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L23
+#. URL: http://smart.who.int/base/downloads.html
+#. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
+#: input/pagecontent/downloads.md:23
+msgid "Examples (XML)"
+msgstr ""
+
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L28
+#. URL: http://smart.who.int/base/downloads.html
+#. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
+#: input/pagecontent/downloads.md:28
+msgid "Excel exports"
+msgstr ""
+
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L19
+#. URL: http://smart.who.int/base/downloads.html
+#. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
+#: input/pagecontent/downloads.md:19
+msgid "FHIR definitions (JSON)"
+msgstr ""
+
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L21
+#. URL: http://smart.who.int/base/downloads.html
+#. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
+#: input/pagecontent/downloads.md:21
+msgid "FHIR definitions (Turtle)"
+msgstr ""
+
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L20
+#. URL: http://smart.who.int/base/downloads.html
+#. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
+#: input/pagecontent/downloads.md:20
+msgid "FHIR definitions (XML)"
 msgstr ""
 
 #. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L14
@@ -93,10 +156,38 @@ msgstr ""
 msgid "File"
 msgstr ""
 
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L30
+#. URL: http://smart.who.int/base/downloads.html
+#. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
+#: input/pagecontent/downloads.md:30
+msgid "Individual resource spreadsheets (.xlsx)"
+msgstr ""
+
 #. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L7
 #. URL: http://smart.who.int/base/downloads.html
 #. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
 #: input/pagecontent/downloads.md:7
 msgid "Large FHIR package files are published as GitHub Release assets rather than being served from this site. Each release is tagged with the IG version."
+msgstr ""
+
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L29
+#. URL: http://smart.who.int/base/downloads.html
+#. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
+#: input/pagecontent/downloads.md:29
+msgid "Schematron validation rules"
+msgstr ""
+
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L25
+#. URL: http://smart.who.int/base/downloads.html
+#. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
+#: input/pagecontent/downloads.md:25
+msgid "ValueSet expansions (JSON)"
+msgstr ""
+
+#. Source: https://github.com/WorldHealthOrganization/smart-base/blob/main/input/pagecontent/downloads.md#L26
+#. URL: http://smart.who.int/base/downloads.html
+#. URL: https://WorldHealthOrganization.github.io/smart-base/downloads.html
+#: input/pagecontent/downloads.md:26
+msgid "ValueSet expansions (XML)"
 msgstr ""
 

--- a/input/scripts/create_package_release.py
+++ b/input/scripts/create_package_release.py
@@ -3,10 +3,11 @@
 
 This script:
 1. Reads the IG version from sushi-config.yaml
-2. Finds large binary artifacts in the output directory
-3. Determines the next available semver tag (appending .N if needed)
-4. Creates a GitHub Release and uploads the assets
-5. Removes the uploaded files from the output directory so they
+2. Bundles loose .xlsx files into spreadsheets.zip
+3. Finds binary artifacts in the output directory
+4. Determines the next available semver tag (appending .N if needed)
+5. Creates a GitHub Release and uploads the assets
+6. Removes the uploaded files from the output directory so they
    don't bloat the gh-pages deployment
 
 Requires:
@@ -25,6 +26,7 @@ import re
 import subprocess
 import sys
 import time
+import zipfile
 from pathlib import Path
 
 import requests
@@ -37,6 +39,7 @@ RELEASE_ASSET_PATTERNS = [
     "package.r4.tgz",
     "package.r4b.tgz",
     "ai.zip",
+    "package-combined.tgz",
     # IG Publisher generated zip archives — binary files that bloat gh-pages
     "definitions.json.zip",
     "definitions.xml.zip",
@@ -49,6 +52,7 @@ RELEASE_ASSET_PATTERNS = [
     "csvs.zip",
     "excels.zip",
     "schematrons.zip",
+    "spreadsheets.zip",
 ]
 
 # MIME types for upload
@@ -113,6 +117,35 @@ def next_release_version(base_version: str, existing_tags: list[str]) -> str:
             max_n = max(max_n, int(m.group(1)))
 
     return f"{base_version}.{max_n + 1}"
+
+
+def bundle_xlsx_files(output_dir: Path) -> Path | None:
+    """Bundle loose .xlsx files in output_dir into spreadsheets.zip.
+
+    The IG Publisher produces individual .xlsx files (e.g.
+    ValueSet-*.xlsx, CodeSystem-*.xlsx).  These are binary files that
+    should not be deployed to gh-pages.  This function collects them
+    into a single spreadsheets.zip archive, then removes the originals.
+
+    Returns the path to spreadsheets.zip, or None if no .xlsx files found.
+    """
+    xlsx_files = sorted(output_dir.glob("*.xlsx"))
+    if not xlsx_files:
+        return None
+
+    zip_path = output_dir / "spreadsheets.zip"
+    print(f"Bundling {len(xlsx_files)} .xlsx file(s) into {zip_path.name}")
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for xlsx in xlsx_files:
+            zf.write(xlsx, xlsx.name)
+
+    # Remove the individual xlsx files from output
+    for xlsx in xlsx_files:
+        xlsx.unlink()
+
+    size_mb = zip_path.stat().st_size / (1024 * 1024)
+    print(f"  Created {zip_path.name} ({size_mb:.1f} MB, {len(xlsx_files)} files)")
+    return zip_path
 
 
 def find_release_assets(output_dir: Path) -> list[Path]:
@@ -189,7 +222,10 @@ def main():
     ig_version = read_ig_version(repo_root)
     print(f"IG version from sushi-config.yaml: {ig_version}")
 
-    # 2. Find assets
+    # 2. Bundle loose .xlsx files into spreadsheets.zip
+    bundle_xlsx_files(output_dir)
+
+    # 3. Find assets
     assets = find_release_assets(output_dir)
     if not assets:
         print("No release assets found in output directory — skipping release creation")
@@ -201,7 +237,7 @@ def main():
         flag = " ⚠️  (>=100 MB — would be stripped from gh-pages)" if size_mb >= 100 else ""
         print(f"  {a.name} ({size_mb:.1f} MB){flag}")
 
-    # 3. Determine next version tag
+    # 4. Determine next version tag
     if not args.dry_run:
         existing = get_existing_tags(token, repo, ig_version)
     else:
@@ -213,7 +249,7 @@ def main():
         print("DRY RUN — would create release and upload assets, then remove from output/")
         return
 
-    # 4. Create release
+    # 5. Create release
     release_name = f"FHIR Package v{release_version}"
     body_lines = [
         f"Automated FHIR package release for IG version **{ig_version}**.",
@@ -235,13 +271,13 @@ def main():
     release_html_url = release["html_url"]
     print(f"Release created: {release_html_url}")
 
-    # 5. Upload assets
+    # 6. Upload assets
     for asset_path in assets:
         print(f"Uploading {asset_path.name}...")
         result = upload_asset(token, upload_url, asset_path)
         print(f"  Uploaded: {result['browser_download_url']}")
 
-    # 6. Remove uploaded files from output dir
+    # 7. Remove uploaded files from output dir
     for asset_path in assets:
         print(f"Removing {asset_path.name} from output directory")
         asset_path.unlink()

--- a/input/scripts/create_package_release.py
+++ b/input/scripts/create_package_release.py
@@ -37,6 +37,18 @@ RELEASE_ASSET_PATTERNS = [
     "package.r4.tgz",
     "package.r4b.tgz",
     "ai.zip",
+    # IG Publisher generated zip archives — binary files that bloat gh-pages
+    "definitions.json.zip",
+    "definitions.xml.zip",
+    "definitions.ttl.zip",
+    "examples.json.zip",
+    "examples.xml.zip",
+    "examples.ttl.zip",
+    "expansions.json.zip",
+    "expansions.xml.zip",
+    "csvs.zip",
+    "excels.zip",
+    "schematrons.zip",
 ]
 
 # MIME types for upload

--- a/input/scripts/create_package_release.py
+++ b/input/scripts/create_package_release.py
@@ -40,6 +40,7 @@ RELEASE_ASSET_PATTERNS = [
     "package.r4b.tgz",
     "ai.zip",
     "package-combined.tgz",
+    "validator.pack",
     # IG Publisher generated zip archives — binary files that bloat gh-pages
     "definitions.json.zip",
     "definitions.xml.zip",


### PR DESCRIPTION
## Summary

- Add 11 IG Publisher-generated zip files (definitions, examples, expansions, csvs, excels, schematrons) to `RELEASE_ASSET_PATTERNS` in `create_package_release.py` so they are uploaded as GitHub Release assets and removed from `output/` before gh-pages deployment
- Update `downloads.md` to document the new release assets

These zip files (up to ~4.7 MB each) are binary artifacts that bloat the gh-pages branch unnecessarily. They should be served from GitHub Releases alongside the existing package files.

**Files added to releases:**
`definitions.json.zip`, `definitions.xml.zip`, `definitions.ttl.zip`, `examples.json.zip`, `examples.xml.zip`, `examples.ttl.zip`, `expansions.json.zip`, `expansions.xml.zip`, `csvs.zip`, `excels.zip`, `schematrons.zip`

## Test plan

- [ ] Verify a downstream IG build creates a release containing the new zip assets
- [ ] Verify the zip files are no longer present in gh-pages after deployment
- [ ] Verify the downloads page lists all release assets correctly

https://claude.ai/code/session_01RHwz3V4ATGdmXGDhBdntu7