### PR TITLE
Fix PR comment scripts failing builds on permission denied

### DIFF
--- a/.github/workflows/ghbuild.yml
+++ b/.github/workflows/ghbuild.yml
@@ -211,6 +211,7 @@ jobs:
 
       - name: Comment on PR - Build started
         if: steps.find_pr.outputs.IS_PR == 'true'
+        continue-on-error: true
         env:
           PR_NUMBER: ${{ steps.find_pr.outputs.PR_NUMBER }}
           GH_REPOSITORY: ${{ github.repository }}
@@ -1020,6 +1021,7 @@ jobs:
 
       - name: Comment on PR - Deployment completed
         if: steps.find_pr.outputs.IS_PR == 'true' && (success() || failure())
+        continue-on-error: true
         env:
           PR_NUMBER: ${{ steps.find_pr.outputs.PR_NUMBER }}
           GH_REPOSITORY: ${{ github.repository }}

--- a/input/scripts/pr_comment_finish.py
+++ b/input/scripts/pr_comment_finish.py
@@ -155,16 +155,16 @@ def update_pr_comment(pr_number: int, repository: str, run_id: int, sha: str, br
     # Try to update existing comment first
     comment_updated = False
     comment_id_file = '/tmp/comment_id.txt'
-    
+
     if os.path.exists(comment_id_file):
         try:
             with open(comment_id_file, 'r') as f:
                 comment_id = f.read().strip()
-            
+
             # Validate comment ID is numeric
             if comment_id.isdigit():
                 update_url = f'https://api.github.com/repos/{repository}/issues/comments/{comment_id}'
-                
+
                 data = {'body': comment_body}
                 for attempt in range(3):
                     try:
@@ -173,6 +173,11 @@ def update_pr_comment(pr_number: int, repository: str, run_id: int, sha: str, br
                             comment_updated = True
                             print(f"Successfully updated existing comment {comment_id}")
                             break
+                        elif response.status_code in (401, 403):
+                            print(f"⚠️ Permission denied updating PR comment (HTTP {response.status_code}).")
+                            print("   This is expected when the caller workflow does not grant pull-requests: write permission.")
+                            print("   The build will continue without PR comments.")
+                            return
                         elif response.status_code >= 500 and attempt < 2:
                             time.sleep(2 ** attempt)
                             continue
@@ -184,22 +189,27 @@ def update_pr_comment(pr_number: int, repository: str, run_id: int, sha: str, br
                             time.sleep(2 ** attempt)
                             continue
                         raise
-            
+
         except Exception as e:
             print(f"Failed to update existing comment: {e}")
-    
+
     # If update failed, create new comment
     if not comment_updated:
         try:
             create_url = f'https://api.github.com/repos/{repository}/issues/{pr_number}/comments'
             data = {'body': comment_body}
-            
+
             for attempt in range(3):
                 try:
                     response = requests.post(create_url, headers=headers, json=data, timeout=30)
                     response.raise_for_status()
                     break
                 except requests.exceptions.HTTPError as e:
+                    if response.status_code in (401, 403):
+                        print(f"⚠️ Permission denied posting PR comment (HTTP {response.status_code}).")
+                        print("   This is expected when the caller workflow does not grant pull-requests: write permission.")
+                        print("   The build will continue without PR comments.")
+                        return
                     if response.status_code >= 500 and attempt < 2:
                         time.sleep(2 ** attempt)
                         continue
@@ -209,12 +219,12 @@ def update_pr_comment(pr_number: int, repository: str, run_id: int, sha: str, br
                         time.sleep(2 ** attempt)
                         continue
                     raise
-            
+
             print("Successfully created new comment")
-            
+
         except requests.exceptions.RequestException as e:
-            print(f"Error creating new PR comment: {e}")
-            sys.exit(1)
+            print(f"⚠️ Failed to post PR comment: {e}")
+            print("   The build will continue without PR comments.")
 
 
 def main():

--- a/input/scripts/pr_comment_start.py
+++ b/input/scripts/pr_comment_start.py
@@ -132,6 +132,11 @@ def post_pr_comment(pr_number: int, repository: str, run_id: int, sha: str, bran
                 response.raise_for_status()
                 break
             except requests.exceptions.HTTPError as e:
+                if response.status_code in (401, 403):
+                    print(f"⚠️ Permission denied posting PR comment (HTTP {response.status_code}).")
+                    print("   This is expected when the caller workflow does not grant pull-requests: write permission.")
+                    print("   The build will continue without PR comments.")
+                    return ""
                 if response.status_code >= 500 and attempt < 2:
                     time.sleep(2 ** attempt)
                     continue
@@ -141,21 +146,22 @@ def post_pr_comment(pr_number: int, repository: str, run_id: int, sha: str, bran
                     time.sleep(2 ** attempt)
                     continue
                 raise
-        
+
         comment_data = response.json()
         comment_id = str(comment_data['id'])
-        
+
         # Save comment ID for later updates
         os.makedirs('/tmp', exist_ok=True)
         with open('/tmp/comment_id.txt', 'w') as f:
             f.write(comment_id)
-        
+
         print(f"Successfully posted PR comment. Comment ID: {comment_id}")
         return comment_id
-        
+
     except requests.exceptions.RequestException as e:
-        print(f"Error posting PR comment: {e}")
-        sys.exit(1)
+        print(f"⚠️ Failed to post PR comment: {e}")
+        print("   The build will continue without PR comments.")
+        return ""
 
 
 def main():


### PR DESCRIPTION
## Summary

- **Fix 403 errors crashing builds in downstream repos**: When repos like `smart-pcmt-vaxprequal` call `ghbuild.yml` without `pull-requests: write` permission, the PR comment scripts got a 403 Forbidden and called `sys.exit(1)`, failing the entire build
- **Handle 401/403 gracefully**: Both `pr_comment_start.py` and `pr_comment_finish.py` now print a warning and continue instead of exiting with error code 1
- **Add `continue-on-error: true`** to both PR comment workflow steps in `ghbuild.yml` as a safety net — PR comments are informational and should never block the build

## Test plan

- [ ] Trigger a build on a downstream repo (e.g. `smart-pcmt-vaxprequal`) with a PR and verify the build no longer fails on the PR comment step
- [ ] Trigger a build on `smart-base` itself with a PR and verify PR comments still post successfully when permissions are correct
- [ ] Verify the warning message appears in the workflow log when permissions are insufficient

https://claude.ai/code/session_01R8Qifz4vasB9Yn7CRzhWPa