### PR TITLE
Remove GitHub Release asset upload step from CI workflow

### DIFF
--- a/.github/workflows/ghbuild.yml
+++ b/.github/workflows/ghbuild.yml
@@ -893,33 +893,6 @@ jobs:
             echo "⚠️ fix_release_links.py not available, skipping"
           fi
 
-      # ── Upload large package files as GitHub Release assets ────────
-      # Instead of deploying package.db, package.tgz, package.r4.tgz,
-      # package.r4b.tgz, and ai.zip to gh-pages (where they bloat the
-      # branch), upload them as binary assets on a GitHub Release tagged
-      # with the IG version from sushi-config.yaml.
-      - name: Upload FHIR package assets as GitHub Release
-        if: success()
-        id: package_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_SHA: ${{ github.sha }}
-        run: |
-          # Check if release script exists locally, download if needed
-          if [ ! -f "input/scripts/create_package_release.py" ]; then
-            echo "Release script not found locally, downloading from smart-base repository..."
-            mkdir -p input/scripts
-            curl -L -f -o "input/scripts/create_package_release.py" \
-              "${SCRIPTS_BASE_URL}/input/scripts/create_package_release.py" \
-              2>/dev/null || echo "Failed to download create_package_release.py"
-          fi
-
-          if [ -f "input/scripts/create_package_release.py" ]; then
-            python3 input/scripts/create_package_release.py --output-dir ./output
-            echo "✅ Package release created"
-          else
-            echo "⚠️ create_package_release.py not available, skipping package release"
-          fi
 
       - name: Delete files >100MB before deployment
         run: |


### PR DESCRIPTION
## Summary
Removed the "Upload FHIR package assets as GitHub Release" step from the GitHub Actions workflow. This step was responsible for uploading large package files (package.db, package.tgz, package.r4.tgz, package.r4b.tgz, and ai.zip) as binary assets to GitHub Releases instead of deploying them to gh-pages.

## Changes
- Removed the entire `Upload FHIR package assets as GitHub Release` job step from `.github/workflows/ghbuild.yml`
- This includes the removal of:
  - Script availability check and conditional download logic for `create_package_release.py`
  - Python script execution to create package releases
  - Associated environment variables (GITHUB_TOKEN, GITHUB_SHA)
  - Success condition check for the step

## Impact
Large package files will no longer be automatically uploaded as GitHub Release assets during the CI/CD pipeline. The subsequent "Delete files >100MB before deployment" step remains in place for the gh-pages deployment process.

https://claude.ai/code/session_014xeaCmB7K2aXe9T8GV9m2f